### PR TITLE
Handle empty data files correctly

### DIFF
--- a/yk
+++ b/yk
@@ -531,7 +531,7 @@ class CLI < Thor
 
       @modules[name] = YastModule.new(
         name,
-        YAML.load_file(file),
+        YAML.load_file(file) || {},
         @modules,
         @config
       )


### PR DESCRIPTION
Without this patch, the following error was displayed when reading an
empty data file:

  undefined method `[]' for false:FalseClass
