### PR TITLE
Remove debugger.yml

### DIFF
--- a/data/debugger.yml
+++ b/data/debugger.yml
@@ -1,5 +1,0 @@
-# TODO: Process.
-
-files:
-  - ycp/Debug.ycp
-  - ycp/eval.ycp


### PR DESCRIPTION
The "debugger" module is obsolete and its .ycp files no longer compile
properly. The new YCP debugger is developed in the "core" module.
