### PR TITLE
Remove cim.yml

### DIFF
--- a/data/cim.yml
+++ b/data/cim.yml
@@ -1,5 +1,0 @@
-# TODO: Process.
-
-files:
-  - testsuite/devel/cim-browser.ycp
-  - testsuite/devel/file-browser.ycp


### PR DESCRIPTION
The "cim" module is an old experiment that is no longer relevant. There
is no package created for openSUSE 12.3.
