### PR TITLE
Add also indirect dependencies into module/include path

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,9 @@ format.
 [yaml]: http://en.wikipedia.org/wiki/YAML
 
 ```
-# A list of modules this one depends on to compile.
+# A list of modules this one depends on to compile. Only direct dependencies
+# need to be stated here (the indirect ones are computed automatically when
+# needed).
 # Default: []
 deps:
   - yast2

--- a/yk
+++ b/yk
@@ -71,6 +71,10 @@ class YastModule
     @moves      = @data["moves"] || []
   end
 
+  def transitive_deps
+    (deps.map { |d| @modules[d].transitive_deps }.reduce([], :+) + deps).uniq
+  end
+
   def convert
     File.exists?(work_dir) ? update : clone
     restructure
@@ -394,7 +398,7 @@ EOS
     # initialized when "initialize" is called on this module.
     unless @module_paths 
       @module_paths = [STUBS_DIR] + exported_module_paths
-      deps.each do |dependency| 
+      transitive_deps.each do |dependency|
         @module_paths.concat @modules[dependency].exported_module_paths
       end
     end
@@ -406,7 +410,7 @@ EOS
     # initialized when "initialize" is called on this module.
     unless @include_paths
       @include_paths = [STUBS_DIR] + exported_include_paths
-      deps.each do |dependency| 
+      transitive_deps.each do |dependency|
         @include_paths.concat @modules[dependency].exported_include_paths
       end
     end


### PR DESCRIPTION
The "lxc" module depends on "security", which depends on "pam". Before
this commit, both "security" and "pam" had to be specified as deps in
lxc.yml. This is wrong, because the fact that "security" depends on
"pam" is an internal thing of the "security" module and it shouldn't
leak elsewhere nor be described multiple times in different .yml files.

This commit fixes this problem in a general way by adding indirect
dependencies to module/include path too.
