### PR TITLE
compile autoinstallation

### DIFF
--- a/data/autoinstallation.yml
+++ b/data/autoinstallation.yml
@@ -1,8 +1,11 @@
 deps:
+  - mouse
   - yast2
+  - packager
+  - update
   - slp
-  - transfer
   - storage
+  - transfer
 
 moves:
   - from: src/{dialogs,include}/*.ycp


### PR DESCRIPTION
Clients doesn't compile due to client dependencies on various modules.
