### PR TITLE
Remove cd-creator.yml

### DIFF
--- a/data/cd-creator.yml
+++ b/data/cd-creator.yml
@@ -1,8 +1,0 @@
-#files:
-#  - src/CDCreator.ycp
-#  - src/cd-creator.ycp
-#  - src/complex.ycp
-#  - src/dialogs.ycp
-#  - src/helps.ycp
-#  - src/routines.ycp
-#  - src/wizards.ycp


### PR DESCRIPTION
According to Jiří Suchomel, cd-creator is dead.
