### PR TITLE
samba-server.yml: Simplify a glob

### DIFF
--- a/data/samba-server.yml
+++ b/data/samba-server.yml
@@ -5,7 +5,7 @@ deps:
   - samba-client
 
 moves:
-  - from: "src/Samba*.{ycp,pm}"
+  - from: "src/Samba*.pm"
     to:   src/modules
   - from: "src/YaPI/*.pm"
     to:   src/modules/YaPI


### PR DESCRIPTION
There are no YCP modules in samba-server, so no need to glob for them.

Suggested by Martin Vidner:

  https://github.com/yast/ycp-killer/pull/178/files#r3851745
