### PR TITLE
Improve progress messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ specified by the `yast_dir` setting in `config.yml`.
 
 ```
 $ ./yk clone testsuite
-[1/1] Cloning testsuite...                                            OK
+[1/1] Processing testsuite:
+  * Cloning...                                                        OK
 ```
 
 #### yk reset
@@ -164,7 +165,8 @@ Use `yk genpatch` beforehand to save them.
 
 ```
 $ ./yk reset testsuite
-[1/1] Resetting testsuite...                                          OK
+[1/1] Processing testsuite:
+  * Resetting...                                                      OK
 ```
 
 #### yk restructure
@@ -180,7 +182,8 @@ to ensure that `yk genpatch` diffs properly against the new structure.
 
 ```
 $ ./yk restructure testsuite
-[1/1] Restructuring testsuite...                                      OK
+[1/1] Processing testsuite:
+  * Restructuring...                                                  OK
 ```
 
 #### yk patch
@@ -190,7 +193,8 @@ checkouts. If a module doesn't have a patch, this command does not do anything.
 
 ```
 $ ./yk patch testsuite
-[1/1] Patching testsuite...                                           OK
+[1/1] Processing testsuite:
+  * Patching...                                                       OK
 ```
 
 #### yk compile
@@ -251,8 +255,8 @@ into a patch in the `patches` directory.
 **Any existing patch for the module is removed**.
 
 ```
-$ ./yk genpatch testsuite
-[1/1] Generating patch testsuite...                                   OK
+[1/1] Processing testsuite:
+  * Generating patch...                                               OK
 ```
 
 #### yk makefile

--- a/yk
+++ b/yk
@@ -117,9 +117,11 @@ class YastModule
   end
 
   def clone
-    FileUtils.rm_rf(work_dir)
+    action "Cloning" do
+      FileUtils.rm_rf(work_dir)
 
-    Cheetah.run "git", "clone", "git://github.com/yast/yast-#@name.git", work_dir
+      Cheetah.run "git", "clone", "git://github.com/yast/yast-#@name.git", work_dir
+    end
   end
 
   def update
@@ -134,26 +136,30 @@ class YastModule
   end
 
   def patch
-    patch_file = "#{PATCHES_DIR}/#{@name}.patch"
-    return unless File.exists?(patch_file)
+    action "Patching" do
+      patch_file = "#{PATCHES_DIR}/#{@name}.patch"
+      next unless File.exists?(patch_file)
 
-    Dir.chdir work_dir do
-      Cheetah.run "git", "apply", patch_file
+      Dir.chdir work_dir do
+        Cheetah.run "git", "apply", patch_file
+      end
     end
   end
 
   def genpatch
-    patch_file = "#{PATCHES_DIR}/#{@name}.patch"
+    action "Generating patch" do
+      patch_file = "#{PATCHES_DIR}/#{@name}.patch"
 
-    FileUtils.rm_rf patch_file
+      FileUtils.rm_rf patch_file
 
-    Dir.chdir work_dir do
-      output = Cheetah.run "git", "diff", :stdout => :capture
-      # git fails to apply empty file, so don't create it
-      return if output.empty?
+      Dir.chdir work_dir do
+        output = Cheetah.run "git", "diff", :stdout => :capture
+        # git fails to apply empty file, so don't create it
+        next if output.empty?
 
-      File.open(patch_file, "w") do |f|
-        f.write output
+        File.open(patch_file, "w") do |f|
+          f.write output
+        end
       end
     end
   end
@@ -168,7 +174,7 @@ class YastModule
 
       ordered_modules.each do |file|
         begin
-          Messages.start "  . #{file}"
+          Messages.start "  * Compiling #{file}..."
           create_ybc file
           Messages.finish "OK"
           @counts[:ok] += 1
@@ -189,7 +195,7 @@ class YastModule
       Dir["**/*.y{cp,h}"].each do |file|
         next if excluded.include?(file)
 
-        Messages.start "  * #{file}"
+        Messages.start "  * Converting #{file}..."
 
         work_file = "#{work_dir}/#{file}"
         FileUtils.rm "#{result_dir}/#{file}"
@@ -230,95 +236,103 @@ class YastModule
   end
 
   def reset
-    Dir.chdir work_dir do
-      Cheetah.run "git", "reset", "--hard", "HEAD"
+    action "Resetting" do
+      Dir.chdir work_dir do
+        Cheetah.run "git", "reset", "--hard", "HEAD"
 
-      output = Cheetah.run "git", "status", "--short", :stdout => :capture
-      output.split("\n").each do |line|
-        if line =~ /^\?\?\s+(.*)$/
-          FileUtils.rm_rf $1
-        else
-          raise "Unknown git file status: #{line}"
+        output = Cheetah.run "git", "status", "--short", :stdout => :capture
+        output.split("\n").each do |line|
+          if line =~ /^\?\?\s+(.*)$/
+            FileUtils.rm_rf $1
+          else
+            raise "Unknown git file status: #{line}"
+          end
         end
       end
     end
   end
 
   def restructure
-    puts "WARNING: No 'moves' section found in #{name}.yml" if moves.empty?
-    Dir.chdir work_dir do
-      moves.each do |move|
-        FileUtils.mkdir_p move["to"]
+    action "Restructuring" do
+      puts "WARNING: No 'moves' section found in #{name}.yml" if moves.empty?
+      Dir.chdir work_dir do
+        moves.each do |move|
+          FileUtils.mkdir_p move["to"]
 
-        from_files = Dir.glob(move["from"])
-        puts "WARNING: typo? no matches for: #{from_glob}" if from_files.empty?
-        from_files.each do |file|
-          # We want the moves stored in git index. This way the "genpatch"
-          # command creates patch against state after restructuring, not
-          # before it.
-          Cheetah.run "git", "mv", file, "#{move["to"]}/#{File.basename(file)}"
+          from_files = Dir.glob(move["from"])
+          puts "WARNING: typo? no matches for: #{from_glob}" if from_files.empty?
+          from_files.each do |file|
+            # We want the moves stored in git index. This way the "genpatch"
+            # command creates patch against state after restructuring, not
+            # before it.
+            Cheetah.run "git", "mv", file, "#{move["to"]}/#{File.basename(file)}"
+          end
         end
       end
     end
   end
 
   def generate_makefiles
-    exports.each do |export_dir|
-      dir = "#{result_dir}/#{export_dir}"
+    action "Generating Makefiles" do
+      exports.each do |export_dir|
+        dir = "#{result_dir}/#{export_dir}"
 
-      Dir["#{dir}/**/Makefile.am"].each do |file|
-        FileUtils.rm file
-      end
+        Dir["#{dir}/**/Makefile.am"].each do |file|
+          FileUtils.rm file
+        end
 
-      File.open("#{dir}/Makefile.am", "w") do |file|
-        dist_variables = []
+        File.open("#{dir}/Makefile.am", "w") do |file|
+          dist_variables = []
 
-        file.puts "# Sources for #{name}"
-        Dir.chdir dir do
-          sections = MAKEFILE_DESCRIPTION.map do |section|
-            result = section.dup
-            result[:files] = Dir[section[:glob]]
+          file.puts "# Sources for #{name}"
+          Dir.chdir dir do
+            sections = MAKEFILE_DESCRIPTION.map do |section|
+              result = section.dup
+              result[:files] = Dir[section[:glob]]
 
-            result
+              result
+            end
+
+            sections.reject! { |section| section[:files].empty? }
+
+            sections = sections.map { |section| split_section(section) }.reduce(&:+)
+
+            sections.each do |section|
+              file.write makefile_entry(section[:key_line] || section[:key], section[:values])
+
+              dist_variables << section[:key]
+            end
+
+            dist_value = dist_variables.map { |v| "$(#{v})" }.join(" ")
+            file.write "\nEXTRA_DIST = #{dist_value}\n\n"
+            file.write 'include $(top_srcdir)/Makefile.am.common'
           end
-
-          sections.reject! { |section| section[:files].empty? }
-
-          sections = sections.map { |section| split_section(section) }.reduce(&:+)
-
-          sections.each do |section|
-            file.write makefile_entry(section[:key_line] || section[:key], section[:values])
-
-            dist_variables << section[:key]
-          end
-
-          dist_value = dist_variables.map { |v| "$(#{v})" }.join(" ")
-          file.write "\nEXTRA_DIST = #{dist_value}\n\n"
-          file.write 'include $(top_srcdir)/Makefile.am.common'
         end
       end
     end
   end
 
   def package
-    Dir.chdir result_dir do
-      Cheetah.run "make", "-f", "Makefile.cvs" # TODO will not work for cmake based ones
-      Cheetah.run "make"
-      Cheetah.run "make", "package-local", "CHECK_SYNTAX=false"
-    end
+    action "Packaging" do
+      Dir.chdir result_dir do
+        Cheetah.run "make", "-f", "Makefile.cvs" # TODO will not work for cmake based ones
+        Cheetah.run "make"
+        Cheetah.run "make", "package-local", "CHECK_SYNTAX=false"
+      end
 
-    package_name = File.read("#{result_dir}/RPMNAME").chomp
+      package_name = File.read("#{result_dir}/RPMNAME").chomp
 
-    FileUtils.mkdir_p obs_dir
-    Dir.chdir obs_dir do
-      package_obs_dir = "#{obs_dir}/#{OBS_PROJECT}/#{package_name}"
+      FileUtils.mkdir_p obs_dir
+      Dir.chdir obs_dir do
+        package_obs_dir = "#{obs_dir}/#{OBS_PROJECT}/#{package_name}"
 
-      create_obs_package_dir!(package_name) unless File.exists?(package_obs_dir)
+        create_obs_package_dir!(package_name) unless File.exists?(package_obs_dir)
 
-      Dir["#{result_dir}/package/*"].each do |file|
-        # for last three arguments keep defaults except last that we switch to
-        # overwrite file in destrination
-        FileUtils.copy_entry file, "#{package_obs_dir}/#{File.basename(file)}", false, false, true
+        Dir["#{result_dir}/package/*"].each do |file|
+          # for last three arguments keep defaults except last that we switch to
+          # overwrite file in destrination
+          FileUtils.copy_entry file, "#{package_obs_dir}/#{File.basename(file)}", false, false, true
+        end
       end
     end
   end
@@ -589,6 +603,19 @@ EOS
     Cheetah.run "ruby", "-c", file
   end
 
+  def action(message)
+    Messages.start "  * #{message}..."
+
+    begin
+      yield
+    rescue Exception => e
+      Messages.finish "ERROR"
+      raise
+    end
+
+    Messages.finish "OK"
+  end
+
   def log_error(file, e)
     File.open(ERROR_FILE, "a") do |f|
       f.puts file
@@ -791,7 +818,7 @@ class CLI < Thor
   desc "clone <module>...", "Clone module(s)"
   def clone(*module_names)
     modules = modules_from_names(module_names)
-    with_modules modules, "Cloning", true do |mod|
+    with_modules modules do |mod|
       mod.clone
     end
   end
@@ -806,7 +833,7 @@ class CLI < Thor
   desc "genpatch <module>...", "Store changes from work directory of module(s) into a patch"
   def genpatch(*module_names)
     modules = modules_from_names(module_names)
-    with_modules modules, "Generating patch", true do |mod|
+    with_modules modules do |mod|
       mod.genpatch
     end
   end
@@ -814,7 +841,7 @@ class CLI < Thor
   desc "patch <module>...", "Patch module(s)"
   def patch(*module_names)
     modules = modules_from_names(module_names)
-    with_modules modules, "Patching", true do |mod|
+    with_modules modules do |mod|
       mod.patch
     end
   end
@@ -822,7 +849,7 @@ class CLI < Thor
   desc "reset <module>...", "Revert module(s) work directory to clean state"
   def reset(*module_names)
     modules = modules_from_names(module_names)
-    with_modules modules, "Resetting", true do |mod|
+    with_modules modules do |mod|
       mod.reset
     end
   end
@@ -830,7 +857,7 @@ class CLI < Thor
   desc "restructure <module>...", "Change module(s) work directory structure to fit the Y2DIR scheme"
   def restructure(*module_names)
     modules = modules_from_names(module_names)
-    with_modules modules, "Restructuring", true do |mod|
+    with_modules modules do |mod|
       mod.restructure
     end
   end
@@ -853,7 +880,7 @@ class CLI < Thor
   desc "makefile <module>...", "Generates Makefile.am for exported dirs of module(s)"
   def makefile(*module_names)
     modules = modules_from_names(module_names)
-    with_modules modules, "Generating Makefiles", true do |mod|
+    with_modules modules do |mod|
       mod.generate_makefiles
     end
   end
@@ -861,7 +888,7 @@ class CLI < Thor
   desc "package <module>...", "Create packages in build service directory for module(s)"
   def package(*module_names)
     modules = modules_from_names(module_names)
-    with_modules modules, "Packaging", true do |mod|
+    with_modules modules do |mod|
       mod.package
     end
   end
@@ -883,7 +910,7 @@ class CLI < Thor
     }
 
     modules = modules_from_names(module_names)
-    with_modules modules, "Compiling", false do |mod|
+    with_modules modules do |mod|
       module_counts = yield(mod)
       counts.keys.each { |k| counts[k] += module_counts[k] }
     end
@@ -937,30 +964,17 @@ class CLI < Thor
     $yast_modules.values_at(*module_names)
   end
 
-  def with_modules(modules, activity, print_status) # :yields: mod
+  def with_modules(modules) # :yields: mod
     max_counter_size = 3 + ((Math.log10(modules.size).to_i + 1) * 2)
 
     modules.each_index do |i|
-      message = sprintf(
+      printf(
         "%-#{max_counter_size}s %s",
         "[#{i + 1}/#{modules.size}]",
-        "#{activity} #{modules[i].name}..."
+        "Processing #{modules[i].name}:\n"
       )
 
-      if print_status
-        Messages.start message
-      else
-        Messages.info message
-      end
-
-      begin
-        yield modules[i]
-      rescue Exception => e
-        Messages.finish "ERROR" if print_status
-        raise
-      end
-
-      Messages.finish "OK" if print_status
+      yield modules[i]
     end
   end
 end


### PR DESCRIPTION
Before this commit, progress messages were crude and sometimes wrong.
This was mostly the case for the "convert" command, which printed
something like this when converting:

```
$ ./yk convert add-on sshd
[1/2] Compiling add-on...
  * src/clients/add-on.ycp                                            OK
  * src/clients/inst_add-on.ycp                                       OK
  * src/clients/vendor.ycp                                            OK
  * src/clients/inst_language_add-on.ycp                              OK
  * src/clients/inst_add-on_software.ycp                              OK
  * src/clients/add-on_proposal.ycp                                   OK
  * src/clients/add-on_auto.ycp                                       OK
  * src/include/add-on/misc.ycp                                       OK
  * src/include/add-on/add-on-workflow.ycp                            OK
[2/2] Compiling sshd...
  . src/modules/Sshd.ycp                                              OK
  . src/modules/SshdCommandLine.ycp                                   OK
  * src/modules/Sshd.ycp                                              OK
  * src/modules/SshdCommandLine.ycp                                   OK
  * src/clients/sshd_auto.ycp                                         OK
  * src/clients/sshd.ycp                                              OK
  * src/include/sshd/wizards.ycp                                      OK
  * src/include/sshd/helps.ycp                                        OK
  * src/include/sshd/complex.ycp                                      OK
  * src/include/sshd/dialogs.ycp                                      OK
  * testsuite/tests/Sshd-SSHDOption.ycp                               OK
  * testsuite/tests/Sshd-Modified.ycp                                 OK
  * testsuite/tests/ag_sshd.ycp                                       OK

-----

Total OK:           20
Total EXCLUDED:     0
Total ERROR(ybc):   0
Total ERROR(y2r):   0
Total ERROR(ruby):  0
Total ERROR(other): 0
```

The phases of the conversion were not visible (which was bad when an
unexpected exception happened) and the description of what is going on
was wrong.

I decided to change the message structure a bit to fix this. At the top
level, only a generic line like "[1/5] Processing add-on:" is printed.
This is a responsitiblity of the CLI class, which iterates over modules.
At the second level, details about the current action are printed (e.g.
"Generating Makefiles...") with possible status info. This is the
responsibility of the YastModule class.

Output of the "convert" command now looks like this:

```
$ ./yk convert add-on sshd
[1/2] Processing add-on:
  * Resetting...                                                      OK
  * Restructuring...                                                  OK
  * Patching...                                                       OK
  * Converting src/clients/add-on.ycp...                              OK
  * Converting src/clients/inst_add-on.ycp...                         OK
  * Converting src/clients/vendor.ycp...                              OK
  * Converting src/clients/inst_language_add-on.ycp...                OK
  * Converting src/clients/inst_add-on_software.ycp...                OK
  * Converting src/clients/add-on_proposal.ycp...                     OK
  * Converting src/clients/add-on_auto.ycp...                         OK
  * Converting src/include/add-on/misc.ycp...                         OK
  * Converting src/include/add-on/add-on-workflow.ycp...              OK
  * Generating Makefiles...                                           OK
  * Packaging...                                                      OK
[2/2] Processing sshd:
  * Resetting...                                                      OK
  * Restructuring...                                                  OK
  * Patching...                                                       OK
  * Compiling src/modules/Sshd.ycp...                                 OK
  * Compiling src/modules/SshdCommandLine.ycp...                      OK
  * Converting src/modules/Sshd.ycp...                                OK
  * Converting src/modules/SshdCommandLine.ycp...                     OK
  * Converting src/clients/sshd_auto.ycp...                           OK
  * Converting src/clients/sshd.ycp...                                OK
  * Converting src/include/sshd/wizards.ycp...                        OK
  * Converting src/include/sshd/helps.ycp...                          OK
  * Converting src/include/sshd/complex.ycp...                        OK
  * Converting src/include/sshd/dialogs.ycp...                        OK
  * Converting testsuite/tests/Sshd-SSHDOption.ycp...                 OK
  * Converting testsuite/tests/Sshd-Modified.ycp...                   OK
  * Converting testsuite/tests/ag_sshd.ycp...                         OK
  * Generating Makefiles...                                           OK
  * Packaging...                                                      OK

-----

Total OK:           20
Total EXCLUDED:     0
Total ERROR(ybc):   0
Total ERROR(y2r):   0
Total ERROR(ruby):  0
Total ERROR(other): 0
```

Better, isn't it?
