### PR TITLE
Make YastModule#{ybc_deps,ruby_deps,transitive_deps} return objects

### DIFF
--- a/lib/commands/convert_command.rb
+++ b/lib/commands/convert_command.rb
@@ -32,9 +32,9 @@ module Commands
     private
 
     # can only be called once all $yast_modules have been initialized
-    def check_missing_work(yast_module_names)
-      missing = yast_module_names.reject do |d|
-        File.exists?($yast_modules[d].work_dir)
+    def check_missing_work(yast_modules)
+      missing = yast_modules.reject do |m|
+        File.exists?(m.work_dir)
       end
       if ! missing.empty?
         raise "These dependencies do not have a working directory; convert them first: #{missing.join(", ")}"


### PR DESCRIPTION
This commit makes YastModule#{ybc_deps,ruby_deps,transitive_deps} return
YastModule objects instead of module names. This has several benefits:
- Code using these methods is simpler as it doesn't need to look up
  the modules.
- There are less references to |$yast_modules| scattered over the
  code (this is related to the previous point).
- It will make topological sorting of YaST modules (something that
  will need to be implemented in order to make |yk compile all| run
  properly on a clean system) easier to do.
