### PR TITLE
README.md: Add gcc-c++ and make installation to the steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ things get gemified, packaged, etc.
 
   4. **Clone the Y2R repository and install Y2R's dependencies**
 
+         $ sudo zypper in gcc-c++ make                  # Needed by Nokogiri
          $ sudo zypper in libxml2-devel libxslt-devel   # Needed by Nokogiri
          $ git clone git://github.com/yast/y2r.git
          $ cd y2r


### PR DESCRIPTION
The "gcc-c++" and "make" packages are needed to compile Nokogiri. They
may not be present on all openSUSE systems.
