### PR TITLE
[Review] Request from '' @ 'yast/ycp-killer/tsort-yast-modules'

### DIFF
--- a/lib/build_order.rb
+++ b/lib/build_order.rb
@@ -1,3 +1,5 @@
+require "tsort"
+
 # based on ycpmakedep script https://github.com/yast/yast-devtools/blob/master/devtools/bin/ycpmakedep
 class BuildOrder
 

--- a/lib/tsorter.rb
+++ b/lib/tsorter.rb
@@ -1,0 +1,56 @@
+require "tsort"
+
+# Simple wrapper around the "tsort" library, which has a horrible API. The main
+# advantage of the wrapper is that you don't need to modify the class that
+# represents sorted objects.
+#
+# Usage:
+#
+#  class Node
+#    attr_accessor :deps
+#
+#    def initialize(index)
+#      @index = index
+#    end
+#
+#    def to_s
+#      "n#@index"
+#    end
+#  end
+#
+#  n1 = Node.new(1)
+#  n2 = Node.new(2)
+#  n3 = Node.new(3)
+#  n4 = Node.new(4)
+#
+#  n1.deps = [n2, n3]
+#  n2.deps = [n3]
+#  n3.deps = []
+#  n4.deps = []
+#
+#  # The passed block is used to get node's dependencies.
+#  TSorter.sort([n1, n2, n3, n4]) do |node|
+#    node.deps
+#  end
+#  # => [n3, n2, n1, n4]
+#
+class TSorter
+  include TSort
+
+  def self.sort(nodes, &block)
+    self.new(nodes, &block).tsort
+  end
+
+  def initialize(nodes, &block)
+    @nodes = nodes
+    @block = block
+  end
+
+  def tsort_each_node(&block)
+    @nodes.each(&block)
+  end
+
+  def tsort_each_child(node, &block)
+    @block.call(node).each(&block)
+  end
+end

--- a/yk
+++ b/yk
@@ -2,7 +2,6 @@
 
 require "cheetah"
 require "thor"
-require "tsort"
 require "yaml"
 
 BASE_DIR = File.expand_path(File.dirname(__FILE__))

--- a/yk
+++ b/yk
@@ -18,6 +18,7 @@ $yast_modules = Hash.new do |hash, missing_key|
   raise "Unknown yast module #{missing_key}"
 end
 
+require_relative "lib/tsorter"
 require_relative "lib/yast_module"
 require_relative "lib/commands/clone_command"
 require_relative "lib/commands/convert_command"
@@ -199,7 +200,7 @@ class CLI < Thor
     module_names = [ module_from_cwd ] if module_names.empty?
     module_names = $yast_modules.keys if module_names == ["all"]
 
-    $yast_modules.values_at(*module_names)
+    TSorter.sort($yast_modules.values_at(*module_names)) { |m| m.ybc_deps }
   end
 
   def with_modules(modules) # :yields: mod


### PR DESCRIPTION
Please review the following changes:
- f6023cb When operating on multiple YaST modules, sort them topologically first
- 293cd4c Move |require "tsort"| to the file where |TSort| is used
