### PR TITLE
Remove the "No 'moves' section" warning

### DIFF
--- a/lib/commands/restructure_command.rb
+++ b/lib/commands/restructure_command.rb
@@ -4,7 +4,6 @@ module Commands
   class RestructureCommand < Command
     def apply(mod)
       action "Restructuring" do
-        puts "WARNING: No 'moves' section found in #{mod.name}.yml" if mod.moves.empty?
         Dir.chdir mod.work_dir do
           mod.moves.each do |move|
             FileUtils.mkdir_p move["to"]


### PR DESCRIPTION
It turns out we have quite some YaST modules where we don't need to do
any restructuring but there are still YCP files to translate there. For
these modules, no "moves" section is present in their .yml file and a
false-positive warning was emitted. For me, this is enough to get rid of
such a warning.
