### PR TITLE
Remove "git pull" called during "convert"

### DIFF
--- a/lib/commands/convert_command.rb
+++ b/lib/commands/convert_command.rb
@@ -7,9 +7,6 @@ module Commands
 
       if File.exists?(mod.work_dir)
         ResetCommand.new(@config).apply(mod)
-        Dir.chdir mod.work_dir do
-          Cheetah.run "git", "pull"
-        end
       else
         CloneCommand.new(@config).apply(mod)
       end


### PR DESCRIPTION
I don't think we should call "git pull" during "convert" if the work
directory exists, only do a reset. The reason is that "pull" can change
the source code you are working with under your hands, which is really
bad during debugging.

If needed, we can add "yk pull" command to invoke "git pull" manually.
