### PR TITLE
Fix a glob warning for "bootloader"

### DIFF
--- a/data/bootloader.yml
+++ b/data/bootloader.yml
@@ -5,8 +5,6 @@ ybc_deps:
   - storage
 
 moves:
-  - from: "src/include/*.ycp"
-    to: src/include/bootloader
   - from: "src/elilo/*.ycp"
     to: src/include/bootloader/elilo
   - from: "src/grub/*.ycp"


### PR DESCRIPTION
Fixes the following warning:

  WARNING: typo? no matches for: src/include/*.ycp

There is no src/include in "bootloader".
