### PR TITLE
Fix a glob in dhcp-server.yml

### DIFF
--- a/data/dhcp-server.yml
+++ b/data/dhcp-server.yml
@@ -14,7 +14,7 @@ moves:
     to: src/include/dhcp-server
   - from: src/*.desktop
     to: src/desktop
-  - from: src/config/*.rnc
+  - from: src/*.rnc
     to: src/autoyast-rnc
   - from: agents/*.scr
     to: src/scrconf


### PR DESCRIPTION
Detected by the following warning:

  WARNING: typo? no matches for: src/config/*.rnc
