### PR TITLE
Remove a glob in inetd.yml

### DIFF
--- a/data/inetd.yml
+++ b/data/inetd.yml
@@ -4,8 +4,6 @@ ybc_deps:
   - users
 
 moves:
-  - from: agents/*.scr
-    to:   src/scrconf
   - from: src/config/*.rnc
     to:   src/autoyast
   - from: src/{xinetd,inetd,inetd_auto,inetd_proposal}.ycp


### PR DESCRIPTION
There are no agents/*.scr files in "inetd".

Detected by the following warning:

  WARNING: typo? no matches for: agents/*.scr
