### PR TITLE
Printer: built successfully, running with client error

### DIFF
--- a/patches/printer.patch
+++ b/patches/printer.patch
@@ -1,3 +1,34 @@
+diff --git a/doc/Makefile.am b/doc/Makefile.am
+index 7ee8d36..091061f 100644
+--- a/doc/Makefile.am
++++ b/doc/Makefile.am
+@@ -1,10 +1,10 @@
+ # Makefile.am for printer/doc
+ 
+-SUBDIRS = autodocs
++# SUBDIRS = autodocs
+ 
+-htmldir = $(docdir)
++# htmldir = $(docdir)
+ 
+-doc_DATA =
+-html_DATA =
++# doc_DATA =
++# html_DATA =
+ 
+-EXTRA_DIST = $(doc_DATA) $(html_DATA)
++# EXTRA_DIST = $(doc_DATA) $(html_DATA)
+diff --git a/doc/autodocs/Makefile.am b/doc/autodocs/Makefile.am
+index f7e5b2d..23dcf72 100644
+--- a/doc/autodocs/Makefile.am
++++ b/doc/autodocs/Makefile.am
+@@ -1,3 +1,4 @@
+ # Makefile.am for printer/doc/autodocs
+-
+-include $(top_srcdir)/autodocs-ycp.ami
++# TODO FIXME: temporarily disabled, enable back when 
++#             autodocs support is implemented
++# include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/src/include/printer/connectionwizard.ycp b/src/include/printer/connectionwizard.ycp
 index 253eff4..dc1bfd2 100644
 --- a/src/include/printer/connectionwizard.ycp
@@ -121,3 +152,16 @@ index 253eff4..dc1bfd2 100644
            break;
      case(`serial):
            string serial_device_node = (string)UI::QueryWidget( `serial_device_node, `Value );
+diff --git a/yast2-printer.spec.in b/yast2-printer.spec.in
+index 27b37f2..2d9e285 100644
+--- a/yast2-printer.spec.in
++++ b/yast2-printer.spec.in
+@@ -55,7 +55,7 @@ chmod 755 %{my_requires}
+ %defattr(-,root,root)
+ %dir @yncludedir@/printer
+ @desktopdir@/printer.desktop
+-@moduledir@/*.y*
++@moduledir@/*.rb
+ @clientdir@/printer*
+ @yncludedir@/printer/*
+ @schemadir@/autoyast/rnc/printer.rnc


### PR DESCRIPTION
- client `printer.rb:51`
  `ycp/wfm.rb:78 Client call failed with stack level too deep and backtrace ["/usr/lib64/ruby/vendor_ruby/1.9.1/ycp/wfm.rb:76"]`
