### PR TITLE
Avoid nil in makefile_command

### DIFF
--- a/lib/commands/makefile_command.rb
+++ b/lib/commands/makefile_command.rb
@@ -73,7 +73,7 @@ module Commands
 
               sections.reject! { |section| section[:files].empty? }
 
-              sections = sections.map { |section| split_section(section) }.reduce(&:+)
+              sections = sections.map { |section| split_section(section) }.reduce([], :+)
 
               sections.each do |section|
                 file.write makefile_entry(section[:key_line] || section[:key], section[:values])


### PR DESCRIPTION
I stumbled upon a nil exception during creating makefilesin dbus-server.
