### PR TITLE
Improve how file names are reported in error.log

### DIFF
--- a/lib/commands/command.rb
+++ b/lib/commands/command.rb
@@ -32,7 +32,7 @@ module Commands
       }
     end
 
-    def handle_exception(e, phase, file)
+    def handle_exception(e, phase, mod, file)
       raise if e.is_a? Interrupt
 
       if ! e.is_a? Cheetah::ExecutionFailed
@@ -40,13 +40,14 @@ module Commands
       end
       Messages.finish "ERROR(#{phase})"
       @counts["error_#{phase}".to_sym] += 1
-      log_error(file, e)
+      log_error(mod, file, e)
     end
 
-    def log_error(file, e)
+    def log_error(mod, file, e)
       File.open(ERROR_FILE, "a") do |f|
-        f.puts file
-        f.puts "-" * file.size
+        header = "[#{mod.name}] #{file}"
+        f.puts header
+        f.puts "-" * header.size
         f.puts
         if e.is_a?(Cheetah::ExecutionFailed)
           f.puts e.stderr

--- a/lib/commands/ruby_command.rb
+++ b/lib/commands/ruby_command.rb
@@ -24,14 +24,14 @@ module Commands
 
             create_rb mod, work_file, result_file
           rescue Exception => e
-            handle_exception(e, :y2r, work_file)
+            handle_exception(e, :y2r, mod, file)
             next
           end
 
           begin
             check_rb result_file
           rescue Exception => e
-            handle_exception(e, :ruby, work_file)
+            handle_exception(e, :ruby, mod, file)
             next
           end
 

--- a/lib/commands/ybc_command.rb
+++ b/lib/commands/ybc_command.rb
@@ -19,7 +19,7 @@ module Commands
             Messages.finish "OK"
             @counts[:ok] += 1
           rescue Exception => e
-            handle_exception(e, :ybc, file)
+            handle_exception(e, :ybc, mod, file)
           end
         end
       end


### PR DESCRIPTION
Before this change, errors in the error log reported by the "ybc"
command contained only part of the filename of the affected file
relative to module's work directory. This made it hard to see which
module that file belonged to. On the other hand, errors reported by the
"ruby" command contained full path to the affected file. These were
sometimes too long.

This commit unifies the behavior and writes the filename into the error
log in format like this:

  [autoinstallation] src/clients/inst_autosetup_upgrade.ycp

The module name is obvious, the path is always relative to module's work
directory, and the line is easily greppable.
