### PR TITLE
Hardware detection: does not build yet

### DIFF
--- a/patches/hardware-detection.patch
+++ b/patches/hardware-detection.patch
@@ -1,0 +1,35 @@
+diff --git a/doc/autodocs/Makefile.am b/doc/autodocs/Makefile.am
+index 842d408..6f7fe55 100644
+--- a/doc/autodocs/Makefile.am
++++ b/doc/autodocs/Makefile.am
+@@ -1,3 +1,4 @@
+ # Makefile.am for .../agent-hardware-detection/doc/autodocs
+-
+-include $(top_srcdir)/autodocs-cc.ami
++# TODO
++# FIXME temporarily disabled
++# include $(top_srcdir)/autodocs-cc.ami
+diff --git a/testsuite/ag_hwprobe.test/ag_hwprobe.exp b/testsuite/ag_hwprobe.test/ag_hwprobe.exp
+index 437379e..41e04cb 100644
+--- a/testsuite/ag_hwprobe.test/ag_hwprobe.exp
++++ b/testsuite/ag_hwprobe.test/ag_hwprobe.exp
+@@ -5,7 +5,7 @@
+ 
+ # get all files matching tests/*.ycp
+ 
+-set filenames [glob $srcdir/tests/*.ycp]
++set filenames [glob $srcdir/tests/*.rb]
+ 
+ # foreach file, call ycp-run (from testsuite/lib)
+ 
+diff --git a/testsuite/tests/Makefile.am b/testsuite/tests/Makefile.am
+index 78aebd5..f8da694 100644
+--- a/testsuite/tests/Makefile.am
++++ b/testsuite/tests/Makefile.am
+@@ -2,5 +2,5 @@
+ # Makefile.am for core/agent-probe/testsuite/tests
+ #
+ 
+-EXTRA_DIST = *.ycp *.out *.err runtest.sh
++EXTRA_DIST = *.rb *.out *.err runtest.sh
+ 


### PR DESCRIPTION
- patch included
- C++ code compilation problem
  `Entering directory `/home/abuild/rpmbuild/BUILD/yast2-hardware-detection-2.22.0/testsuite'`
  `g++ -DHAVE_CONFIG_H -I. -I.. -I/usr/include/YaST2   -DY2LOG=\"agent-probe\" -fmessage-length=0 -grecord-gcc-switches -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector -funwind-tables -fasynchronous-unwind-tables -DNDEBUG -std=gnu++0x -DHAVE_CXX0X  -Wall -Wformat=2 -MT runag_hwprobe.o -MD -MP -MF .deps/runag_hwprobe.Tpo -c -o runag_hwprobe.o runag_hwprobe.cc`
  `runag_hwprobe.cc:10:28: fatal error: ../src/HwProbe.h: No such file or directory`
  `compilation terminated.`
