### PR TITLE
Fix compilation of the "fingerprint-reader" module

### DIFF
--- a/data/fingerprint-reader.yml
+++ b/data/fingerprint-reader.yml
@@ -2,6 +2,9 @@ ybc_deps:
   - yast2
   - pam
 
+ruby_deps:
+  - users
+
 moves:
   - from: "src/*FingerprintReader.{ycp,pm}"
     to:   src/modules


### PR DESCRIPTION
Without this change, "yk ruby fingerprint-reader" didn't succeed.
