### PR TITLE
Fix compilation of the "online-update-configuration" module

### DIFF
--- a/data/online-update-configuration.yml
+++ b/data/online-update-configuration.yml
@@ -1,6 +1,9 @@
 ybc_deps:
   - yast2
 
+ruby_deps:
+  - packager
+
 moves:
   - from: "src/dialogs/OUCDialogs.ycp"
     to:   src/include/online-update-configuration


### PR DESCRIPTION
Without this change, "yk ruby online-update-configuration" didn't
succeed.
