### PR TITLE
"online-update-test" is obsoleted, remove it

### DIFF
--- a/data/online-update-test.yml
+++ b/data/online-update-test.yml
@@ -1,1 +1,0 @@
-# Nothing to do.


### PR DESCRIPTION
- the last commit was in 2005
- the tests are for "SuSE Linux 9.1" distribution
