### PR TITLE
Always use system ycpc

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -3,10 +3,6 @@
 # Path to a directory where YaST modules can be checked out.
 yast_dir: ""
 
-# Path to the ycpc binary to use (preferably a custom-compiled one from
-# yast-core's Git repository checkout).
-ycpc:     "<git-checkout-dir>/yast-core/base/tools/ycpc/ycpc"
-
 # Path to the Y2R binary to use (preferably a one from Y2R's Git repository
 # checkout).
 y2r:      "<git-checkout-dir>/y2r/bin/y2r"

--- a/lib/commands/ruby_command.rb
+++ b/lib/commands/ruby_command.rb
@@ -50,7 +50,6 @@ module Commands
 
     def create_rb(mod, file, output_file)
       cmd = [@config["y2r"]]
-      cmd << "--ycpc" << @config["ycpc"]
 
       mod.ruby_module_paths(file).each do |module_path|
         cmd << "--module-path" << module_path

--- a/lib/commands/ybc_command.rb
+++ b/lib/commands/ybc_command.rb
@@ -37,7 +37,7 @@ module Commands
     end
 
     def create_ybc(mod, file)
-      cmd = [@config["ycpc"], "--no-std-includes", "--no-std-modules"]
+      cmd = ["ycpc", "--no-std-includes", "--no-std-modules"]
       mod.ybc_module_paths.each do |module_path|
         cmd << "--module-path" << module_path
       end

--- a/yk
+++ b/yk
@@ -198,7 +198,7 @@ class CLI < Thor
 
   def compile_stubs
     Dir["#{STUBS_DIR}/*.ycp"].each do |file|
-      Cheetah.run @config["ycpc"], "-c", file
+      Cheetah.run "ycpc", "-c", file
     end
   end
 


### PR DESCRIPTION
The README.md suggests to install yast2-core from our testing repo,
which will bring our custom ycpc binary into the system. There should be
no reason not to use it.

If someone really really needs to use a non-system ycpc, he can set up a
symlink.
