### PR TITLE
Remove invalid chunk from heartbeat.patch

### DIFF
--- a/patches/heartbeat.patch
+++ b/patches/heartbeat.patch
@@ -60,13 +60,6 @@ diff --git a/src/include/heartbeat/log_conf.ycp b/src/include/heartbeat/log_conf
 index 1302d3a..8b2d23c 100644
 --- a/src/include/heartbeat/log_conf.ycp
 +++ b/src/include/heartbeat/log_conf.ycp
-@@ -59,7 +59,6 @@ import "SCR";
- include "heartbeat/helps.ycp";
- include "heartbeat/common.ycp";
- 
- any log_conf_Read()
- {
-     return true;
 @@ -93,7 +92,9 @@ term timeouts_conf_getDialog()
  
  any ConfigureTimeoutsDialog () {


### PR DESCRIPTION
Without the removal, "yk patch hearbeat" complained:

  fatal: corrupt patch at line 70
