### PR TITLE
Unset RUBYOPT set by bundler

### DIFF
--- a/lib/commands/command.rb
+++ b/lib/commands/command.rb
@@ -66,17 +66,17 @@ module Commands
       end
     end
 
-    # A wrapper for safe restoring environment after changes
+    # A wrapper for saving and restoring environment after changes
     #
     # Example:
     #
-    #   with_env do
+    #   save_env do
     #     ENV["foo"] = bar
     #     foo()
     #   end
     #
     #   # here is the original ENV restored
-    def with_env
+    def save_env
       begin
         env_old = ENV
         yield

--- a/lib/commands/command.rb
+++ b/lib/commands/command.rb
@@ -65,5 +65,24 @@ module Commands
         f.puts
       end
     end
+
+    # A wrapper for safe restoring environment after changes
+    #
+    # Example:
+    #
+    #   with_env do
+    #     ENV["foo"] = bar
+    #     foo()
+    #   end
+    #
+    #   # here is the original ENV restored
+    def with_env
+      begin
+        env_old = ENV
+        yield
+      ensure
+        ENV.replace env_old
+      end
+    end
   end
 end

--- a/lib/commands/package_command.rb
+++ b/lib/commands/package_command.rb
@@ -8,7 +8,7 @@ module Commands
     def apply(mod)
       action "Packaging" do
         Dir.chdir mod.result_dir do
-          with_env do
+          save_env do
             # unset RUBYOPT (set by bundler) to not check for configured
             # rubygems in external ruby scripts called during packaging
             ENV.delete "RUBYOPT"

--- a/lib/commands/package_command.rb
+++ b/lib/commands/package_command.rb
@@ -8,8 +8,13 @@ module Commands
     def apply(mod)
       action "Packaging" do
         Dir.chdir mod.result_dir do
-          Cheetah.run "make", "-f", "Makefile.cvs" # TODO will not work for cmake based ones
-          Cheetah.run "make", "package-local", "CHECK_SYNTAX=false"
+          with_env do
+            # unset RUBYOPT (set by bundler) to not check for configured
+            # rubygems in external ruby scripts called during packaging
+            ENV.delete "RUBYOPT"
+            Cheetah.run "make", "-f", "Makefile.cvs" # TODO will not work for cmake based ones
+            Cheetah.run "make", "package-local", "CHECK_SYNTAX=false"
+          end
         end
 
         FileUtils.mkdir_p mod.obs_base_dir

--- a/lib/commands/ruby_command.rb
+++ b/lib/commands/ruby_command.rb
@@ -15,24 +15,26 @@ module Commands
         prepare_result_dir(mod)
       end
 
-      # This makes private symbols in modules visible. Needed by some
-      # testsuites.
-      ENV["Y2ALLGLOBAL"] = "1"
+      with_env do
+        # This makes private symbols in modules visible. Needed by some
+        # testsuites.
+        ENV["Y2ALLGLOBAL"] = "1"
 
-      Dir.chdir mod.work_dir do
-        Threading.in_parallel Dir["**/*.y{cp,h}"] do |file|
-          next if mod.excluded.include?(file)
+        Dir.chdir mod.work_dir do
+          Threading.in_parallel Dir["**/*.y{cp,h}"] do |file|
+            next if mod.excluded.include?(file)
 
-          work_file = "#{mod.work_dir}/#{file}"
-          FileUtils.rm "#{mod.result_dir}/#{file}"
-          result_file = "#{mod.result_dir}/#{file}".sub(/\.y(cp|h)$/, ".rb")
+            work_file = "#{mod.work_dir}/#{file}"
+            FileUtils.rm "#{mod.result_dir}/#{file}"
+            result_file = "#{mod.result_dir}/#{file}".sub(/\.y(cp|h)$/, ".rb")
 
-          file_action "Converting", :y2r, mod, file do
-            create_rb mod, work_file, result_file
-          end
+            file_action "Converting", :y2r, mod, file do
+              create_rb mod, work_file, result_file
+            end
 
-          file_action "Checking", :ruby, mod, file do
-            check_rb result_file
+            file_action "Checking", :ruby, mod, file do
+              check_rb result_file
+            end
           end
         end
       end

--- a/lib/commands/ruby_command.rb
+++ b/lib/commands/ruby_command.rb
@@ -15,7 +15,7 @@ module Commands
         prepare_result_dir(mod)
       end
 
-      with_env do
+      save_env do
         # This makes private symbols in modules visible. Needed by some
         # testsuites.
         ENV["Y2ALLGLOBAL"] = "1"


### PR DESCRIPTION
to not check for configured rubygems in external ruby scripts called during packaging
- added "with_env" wrapper
- use it also in "ruby" command
