### PR TITLE
build order: fix network (hack within the flawed design)

### DIFF
--- a/lib/build_order.rb
+++ b/lib/build_order.rb
@@ -91,7 +91,7 @@ class BuildOrder
     modules = {}
 
     source_dirs.each do |dir|
-      Dir["#{dir}/modules/**/*.ycp"].each do |file|
+      Dir["#{dir}/modules/**/*.ycp"].sort.each do |file|
         relative_path = file.sub(/#{Regexp.escape(dir)}\/modules\//, "")
         module_name = relative_path.sub(/\.ycp$/, "")
 
@@ -106,7 +106,7 @@ class BuildOrder
     includes = {}
 
     source_dirs.each do |dir|
-      Dir["#{dir}/include/**/*.y{cp,h}"].each do |file|
+      Dir["#{dir}/include/**/*.y{cp,h}"].sort.each do |file|
         relative_path = file.sub(/#{Regexp.escape(dir)}\/include\//, "")
         include_name = relative_path.sub(/\.y(cp|h)$/, "")
 


### PR DESCRIPTION
The problem is exposed in yast2-network if Dir returns ISDN.ycp
earlier than NetHwDetection.ycp. It turns out that sorting the
directory listings hides the problem in all modules so we do just
that.

The problem is that when we attempt to break the module-include
dependency cycles we lose a module-include-module dependency. A way
to fix it would be to recurse over the includes first and solve the
dependencies over modules only (like the original ycpmakedep does!)
but the "sort" hack is a better effort-quality tradeoff.
