### PR TITLE
testsuite: unbreak downstream by excluding Pkg.ycp

### DIFF
--- a/data/testsuite.yml
+++ b/data/testsuite.yml
@@ -3,3 +3,5 @@ moves:
     to: "src/modules/"
   - from: "src/testsuite.ycp"
     to: "src/include/"
+excluded:
+  - src/modules/Pkg.ycp


### PR DESCRIPTION
it is an outdated mock of package-bindings, commented out in
Makefile.am
