### PR TITLE
Stub MasterCFParser.pm

### DIFF
--- a/stubs/MasterCFParser.pm
+++ b/stubs/MasterCFParser.pm
@@ -5,5 +5,7 @@
 #   syntax error at /usr/lib/YaST2/servers_non_y2/MasterCFParser.pm line 406, near "{command :"
 #   Missing right curly or square bracket at /usr/lib/YaST2/servers_non_y2/MasterCFParser.pm line 499, at end of line
 #   /usr/lib/YaST2/servers_non_y2/MasterCFParser.pm had compilation errors.
+#
+# See bnc#800788.
 
 1;

--- a/stubs/MasterCFParser.pm
+++ b/stubs/MasterCFParser.pm
@@ -1,0 +1,9 @@
+# Stubbed because otherwise the "mail" YaST module will attempt to load this
+# file from the system, where it is broken:
+#
+#   $ perl -c /usr/lib/YaST2/servers_non_y2/MasterCFParser.pm
+#   syntax error at /usr/lib/YaST2/servers_non_y2/MasterCFParser.pm line 406, near "{command :"
+#   Missing right curly or square bracket at /usr/lib/YaST2/servers_non_y2/MasterCFParser.pm line 499, at end of line
+#   /usr/lib/YaST2/servers_non_y2/MasterCFParser.pm had compilation errors.
+
+1;


### PR DESCRIPTION
Stubbed because otherwise the "mail" YaST module will attempt to load
this file from the system, where it is broken.
