### PR TITLE
yast2: avoid overlap between original and restructured trees

### DIFF
--- a/data/yast2.yml
+++ b/data/yast2.yml
@@ -2,7 +2,7 @@ ybc_deps:
   - testsuite
 exports:
   - library/types/src
-  - src
+  - library/general/src
   - library/runlevel/src
   - library/sequencer/src
   - library/xml/src
@@ -21,8 +21,10 @@ exports:
 moves:
   # move it to separate dir, otherwise it break Y2DIR scheme as there will
   # be more directories than expected
-  - from: "library/modules"
-    to: src
+  - from: "library/modules/testsuite"
+    to: library/general/testsuite
+  - from: "library/modules/*.{pm,ycp,ycp.in}"
+    to: library/general/src/modules
   - from: "library/agents/*.scr"
     to: src/scrconf
   - from: "library/agents/ag_*"

--- a/patches/yast2.patch
+++ b/patches/yast2.patch
@@ -1,5 +1,5 @@
 diff --git a/configure.in.in b/configure.in.in
-index eaa7454..2e8623b 100644
+index eaa7454..4cbb1d1 100644
 --- a/configure.in.in
 +++ b/configure.in.in
 @@ -32,6 +32,6 @@ AC_MSG_RESULT([$IFCFG_DIR])
@@ -8,7 +8,7 @@ index eaa7454..2e8623b 100644
  # also done via makefile
 -AC_CONFIG_FILES(library/modules/Version.ycp
 -library/network/agents/network.scr)
-+AC_CONFIG_FILES(src/modules/Version.ycp
++AC_CONFIG_FILES(library/general/src/modules/Version.ycp
 +library/network/src/scrconf/network.scr)
  @YAST2-OUTPUT@
 diff --git a/data/Makefile.am b/data/Makefile.am


### PR DESCRIPTION
The overlap would cause problems like:
- Compiling src/modules/modules/Crash.ycp...
  ERROR: Compiling src/modules/modules/Crash.ycp failed.

(which I mistakenly attributed to threading)
or

  fatal: cannot move directory over file, source=library/modules, destination=src/modules/modules

Therefore moving the original library/modules (which was in the
meantime src/modules) to library/general/src/modules.
