### PR TITLE
Patch all spec files to require yast2-ruby-bindings

### DIFF
--- a/patches/add-on-creator.patch
+++ b/patches/add-on-creator.patch
@@ -94,10 +94,19 @@ index e01a5cf..9ada241 100644
  // how to show and handle pattern keys
  map pattern_descr	= AddOnCreator::pattern_descr;
 diff --git a/yast2-add-on-creator.spec.in b/yast2-add-on-creator.spec.in
-index a4deceb..3691d5a 100644
+index a4deceb..653f268 100644
 --- a/yast2-add-on-creator.spec.in
 +++ b/yast2-add-on-creator.spec.in
-@@ -29,7 +29,7 @@ A wizard for creating your own Add-On product
+@@ -9,6 +9,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - module for creating Add-On product
+ 
+ %description
+@@ -29,7 +31,7 @@ A wizard for creating your own Add-On product
  %defattr(-,root,root)
  %dir @yncludedir@/add-on-creator
  @yncludedir@/add-on-creator/*

--- a/patches/add-on.patch
+++ b/patches/add-on.patch
@@ -1,5 +1,5 @@
 diff --git a/doc/Makefile.am b/doc/Makefile.am
-index f92f253..5aee244 100644
+index f92f253..c7df380 100644
 --- a/doc/Makefile.am
 +++ b/doc/Makefile.am
 @@ -1,6 +1,7 @@
@@ -12,10 +12,19 @@ index f92f253..5aee244 100644
  htmldir = $(docdir)
  
 diff --git a/yast2-add-on.spec.in b/yast2-add-on.spec.in
-index ef8280b..21f7eaa 100644
+index ef8280b..246c4f8 100644
 --- a/yast2-add-on.spec.in
 +++ b/yast2-add-on.spec.in
-@@ -46,11 +46,11 @@ This package contains YaST Add-On media installation code.
+@@ -29,6 +29,8 @@ Conflicts:	yast2-pkg-bindings < 2.17.25
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Add-On media installation code
+ 
+ %description
+@@ -46,11 +48,11 @@ This package contains YaST Add-On media installation code.
  %defattr(-,root,root)
  %dir @yncludedir@/add-on
  @yncludedir@/add-on/*

--- a/patches/apparmor.patch
+++ b/patches/apparmor.patch
@@ -79,3 +79,16 @@ index 0d6a829..1796a59 100644
  
  string modeHelp = _("<p><b>Profile Mode Configuration</b><br>This tool allows 
  you to set AppArmor profiles to either complain or enforce mode.</p>") +
+diff --git a/yast2-apparmor.spec.in b/yast2-apparmor.spec.in
+index 4da1fd4..19fd342 100644
+--- a/yast2-apparmor.spec.in
++++ b/yast2-apparmor.spec.in
+@@ -4,6 +4,8 @@
+ Group:	Productivity/Security
+ License: GPL-2.0
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary: YaST2 - Plugins for AppArmor Profile Management
+ 
+ Requires: yast2 

--- a/patches/audit-laf.patch
+++ b/patches/audit-laf.patch
@@ -20,10 +20,19 @@ index 243cd8d..99807b9 100644
 +
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-audit-laf.spec.in b/yast2-audit-laf.spec.in
-index b25e33e..b7938c5 100644
+index b25e33e..aa24892 100644
 --- a/yast2-audit-laf.spec.in
 +++ b/yast2-audit-laf.spec.in
-@@ -28,8 +28,8 @@ add rules for the audit subsystem.
+@@ -9,6 +9,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Configuration of Linux Auditing (LAF)
+ 
+ %description
+@@ -28,8 +30,8 @@ add rules for the audit subsystem.
  %dir @yncludedir@/audit-laf
  @yncludedir@/audit-laf/*
  %dir @clientdir@

--- a/patches/autofs.patch
+++ b/patches/autofs.patch
@@ -265,10 +265,19 @@ index f230f4d..52cdd7f 100644
  
  /**
 diff --git a/yast2-autofs.spec.in b/yast2-autofs.spec.in
-index e157043..11b4227 100644
+index e157043..298370e 100644
 --- a/yast2-autofs.spec.in
 +++ b/yast2-autofs.spec.in
-@@ -29,8 +29,8 @@ under ou=AUTOFS,$LDAPBASE.
+@@ -9,6 +9,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Module to Create and Manage autofs Entries in LDAP
+ 
+ %description
+@@ -29,8 +31,8 @@ under ou=AUTOFS,$LDAPBASE.
  %defattr(-,root,root)
  %dir @yncludedir@/autofs
  @yncludedir@/autofs/*

--- a/patches/autoinstallation.patch
+++ b/patches/autoinstallation.patch
@@ -15,10 +15,28 @@ index 4110426..e69de29 100644
 -
 -EXTRA_DIST = $(scrconf_DATA)  $(agent_SCRIPTS)
 diff --git a/autoyast2.spec.in b/autoyast2.spec.in
-index c7196fd..3f5d91a 100644
+index c7196fd..bb38ea3 100644
 --- a/autoyast2.spec.in
 +++ b/autoyast2.spec.in
-@@ -110,31 +110,32 @@ rmdir $RPM_BUILD_ROOT/@docdir@/html/autoyast
+@@ -27,6 +27,8 @@ PreReq:		%insserv_prereq %fillup_prereq
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Automated Installation
+ 
+ %description
+@@ -40,6 +42,8 @@ This file contains YaST2-independent files needed to create
+ installation sources.
+ 
+ %package installation
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Auto Installation Modules
+ Group:		System/YaST
+ # API for Disabled Modules (ProductControl)
+@@ -110,31 +114,32 @@ rmdir $RPM_BUILD_ROOT/@docdir@/html/autoyast
  
  @desktopdir@/autoyast.desktop
  /usr/share/autoinstall/modules/*.desktop
@@ -69,7 +87,7 @@ index c7196fd..3f5d91a 100644
  @agentdir@/ag_ksimport
  
  
-@@ -168,58 +169,58 @@ rmdir $RPM_BUILD_ROOT/@docdir@/html/autoyast
+@@ -168,58 +173,58 @@ rmdir $RPM_BUILD_ROOT/@docdir@/html/autoyast
  /usr/share/autoinstall/xslt/merge.xslt
  # config file
  

--- a/patches/backup.patch
+++ b/patches/backup.patch
@@ -22,10 +22,19 @@ index 2a6f678..9de7be0 100644
 +
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-backup.spec.in b/yast2-backup.spec.in
-index 3f5b8fc..8e60dce 100644
+index 3f5b8fc..c09f5f2 100644
 --- a/yast2-backup.spec.in
 +++ b/yast2-backup.spec.in
-@@ -65,10 +65,9 @@ backs them up.
+@@ -4,6 +4,8 @@
+ Group:          System/YaST
+ License:        GPL-2.0
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:		YaST2 - System Backup
+ BuildArchitectures:	noarch
+ 
+@@ -65,10 +67,9 @@ backs them up.
  @agentdir@/ag_file_append
  @scrconfdir@/cfg_backup.scr
  @yncludedir@/backup/*

--- a/patches/boot-server.patch
+++ b/patches/boot-server.patch
@@ -35,10 +35,19 @@ index ed7a5a6..3be59d2 100644
 +
 +#CLEANFILES = $(html_DATA)
 diff --git a/yast2-boot-server.spec.in b/yast2-boot-server.spec.in
-index 4c884ee..95ad3d0 100644
+index 4c884ee..ed28286 100644
 --- a/yast2-boot-server.spec.in
 +++ b/yast2-boot-server.spec.in
-@@ -24,7 +24,7 @@ YaST2 module for network booting and Wake-On-Lan.
+@@ -8,6 +8,8 @@ Requires:	yast2
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Network Booting and Wake-On-Lan Configuration
+ 
+ %description
+@@ -24,7 +26,7 @@ YaST2 module for network booting and Wake-On-Lan.
  
  %files
  %defattr(-,root,root)

--- a/patches/bootloader.patch
+++ b/patches/bootloader.patch
@@ -1105,10 +1105,19 @@ index f756b6c..5659a4f 100644
  import "Linuxrc";
  
 diff --git a/yast2-bootloader.spec.in b/yast2-bootloader.spec.in
-index dac4bd0..325d018 100644
+index dac4bd0..6db7cfa 100644
 --- a/yast2-bootloader.spec.in
 +++ b/yast2-bootloader.spec.in
-@@ -66,9 +66,9 @@ This package contains the YaST2 component for bootloader configuration.
+@@ -36,6 +36,8 @@ Obsoletes:	y2c_boot y2t_boot
+ Provides:	y2t_inst-bootloader yast2-agent-liloconf-devel yast2-agent-prom-devel
+ Obsoletes:	y2t_inst-bootloader yast2-agent-liloconf-devel yast2-agent-prom-devel
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Bootloader Configuration
+ 
+ %description
+@@ -66,9 +68,9 @@ This package contains the YaST2 component for bootloader configuration.
  %dir @yncludedir@/bootloader
  @yncludedir@/bootloader/*
  @moduledir@/*

--- a/patches/ca-management.patch
+++ b/patches/ca-management.patch
@@ -92,10 +92,19 @@ index 223f310..5882646 100644
      // Description of the current Request
      map currentRequestMap = $[];
 diff --git a/yast2-ca-management.spec.in b/yast2-ca-management.spec.in
-index 05afd3f..4c8d80b 100644
+index 05afd3f..04a8c8e 100644
 --- a/yast2-ca-management.spec.in
 +++ b/yast2-ca-management.spec.in
-@@ -45,14 +45,14 @@ Managing CAs, Certificates and Requests in an understanding way.
+@@ -27,6 +27,8 @@ Requires:       perl-gettext
+ Requires:       yast2 >= 2.21.22
+ Requires:       yast2-perl-bindings
+ BuildArch:      noarch
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:        YaST2 - CAs, Certificates and Requests Management
+ 
+ %description
+@@ -45,14 +47,14 @@ Managing CAs, Certificates and Requests in an understanding way.
  %dir @moduledir@/YaPI
  %dir @moduledir@/YaST
  @yncludedir@/ca-management/*

--- a/patches/certify.patch
+++ b/patches/certify.patch
@@ -61,10 +61,10 @@ index 71b4c62..3fd9c7d 100644
  	string statusmsg = _("Current Status: %1");
  
 diff --git a/yast2-certify.spec.in b/yast2-certify.spec.in
-index 526f418..871867c 100644
+index 526f418..35192b0 100644
 --- a/yast2-certify.spec.in
 +++ b/yast2-certify.spec.in
-@@ -1,8 +1,10 @@
+@@ -1,12 +1,16 @@
  @HEADER-COMMENT@
 -# neededforbuild yast2-devel-packages
  
@@ -76,7 +76,13 @@ index 526f418..871867c 100644
  Provides:	y2m_certify yast2-module-certify
  Obsoletes:	y2m_certify yast2-module-certify
  BuildArchitectures:	noarch
-@@ -24,7 +26,7 @@ Summary:	Self certification
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	Self certification
+ 
+ %description
+@@ -24,7 +28,7 @@ Summary:	Self certification
  %defattr(-,root,root)
  %dir @yncludedir@/certify
  @yncludedir@/certify/*

--- a/patches/cluster.patch
+++ b/patches/cluster.patch
@@ -64,10 +64,19 @@ index ce438f1..9623c97 100644
  list<string> csync2_suggest_files = ["/etc/corosync/corosync.conf",
  	"/etc/corosync/authkey", "/etc/sysconfig/pacemaker",
 diff --git a/yast2-cluster.spec.in b/yast2-cluster.spec.in
-index 6063b4e..3ca9ef3 100644
+index 6063b4e..8c80699 100644
 --- a/yast2-cluster.spec.in
 +++ b/yast2-cluster.spec.in
-@@ -23,12 +23,10 @@ Summary:	Configuration of cluster
+@@ -6,6 +6,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	Configuration of cluster
+ 
+ %description
+@@ -23,12 +25,10 @@ Summary:	Configuration of cluster
  %defattr(-,root,root)
  %dir @yncludedir@/cluster
  @yncludedir@/cluster/*

--- a/patches/country.patch
+++ b/patches/country.patch
@@ -434,10 +434,19 @@ index 7cf268b..329d1e9 100644
      // help for timezone screen
      string help_text = _("
 diff --git a/yast2-country.spec.in b/yast2-country.spec.in
-index 2361cda..b123c13 100644
+index 2361cda..b6eebe8 100644
 --- a/yast2-country.spec.in
 +++ b/yast2-country.spec.in
-@@ -74,13 +74,13 @@ install -m 0644 %SOURCE2 $RPM_BUILD_ROOT/usr/share/polkit-1/actions/
+@@ -50,6 +50,8 @@ Obsoletes:	y2t_inst-language
+ Provides:	y2t_inst-environment
+ Obsoletes:	y2t_inst-environment
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Country Settings (Language, Keyboard, and Timezone)
+ 
+ %description
+@@ -74,13 +76,13 @@ install -m 0644 %SOURCE2 $RPM_BUILD_ROOT/usr/share/polkit-1/actions/
  %defattr(-,root,root)
  %doc @docdir@
  %doc COPYING
@@ -455,7 +464,16 @@ index 2361cda..b123c13 100644
  @ydatadir@/*.ycp
  @yncludedir@/keyboard/
  @yncludedir@/timezone/
-@@ -105,4 +105,4 @@ functions (Language module)
+@@ -94,6 +96,8 @@ install -m 0644 %SOURCE2 $RPM_BUILD_ROOT/usr/share/polkit-1/actions/
+ %attr(644,root,root) %config /usr/share/polkit-1/actions/org.opensuse.yast.modules.yapi.*.policy
+ 
+ %package data
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Data files for Country settings
+ Group:          System/YaST
+ 
+@@ -105,4 +109,4 @@ functions (Language module)
  %defattr(-,root,root)
  %dir @ydatadir@/languages
  @ydatadir@/languages/*.ycp

--- a/patches/crowbar.patch
+++ b/patches/crowbar.patch
@@ -24,10 +24,19 @@ index e7ddf79..14c6419 100644
 +#AUTODOCS_YCP=$(srcdir)/../../src/*.ycp
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-crowbar.spec.in b/yast2-crowbar.spec.in
-index 6eb4ea3..d331b87 100644
+index 6eb4ea3..84b06a9 100644
 --- a/yast2-crowbar.spec.in
 +++ b/yast2-crowbar.spec.in
-@@ -23,8 +23,8 @@ Summary:	Configuration of crowbar
+@@ -6,6 +6,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	Configuration of crowbar
+ 
+ %description
+@@ -23,8 +25,8 @@ Summary:	Configuration of crowbar
  %defattr(-,root,root)
  %dir @yncludedir@/crowbar
  @yncludedir@/crowbar/*

--- a/patches/dhcp-server.patch
+++ b/patches/dhcp-server.patch
@@ -670,10 +670,19 @@ index 285ec51..7278154 100644
  
      map aliases = $[
 diff --git a/yast2-dhcp-server.spec.in b/yast2-dhcp-server.spec.in
-index 90af475..34eff11 100644
+index 90af475..ca4dbee 100644
 --- a/yast2-dhcp-server.spec.in
 +++ b/yast2-dhcp-server.spec.in
-@@ -33,8 +33,8 @@ configuration.
+@@ -15,6 +15,8 @@ Requires: yast2-dns-server >= 2.13.16
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - DHCP Server Configuration
+ 
+ %description
+@@ -33,8 +35,8 @@ configuration.
  %defattr(-,root,root)
  %dir @yncludedir@/dhcp-server
  @yncludedir@/dhcp-server/*

--- a/patches/dirinstall.patch
+++ b/patches/dirinstall.patch
@@ -26,10 +26,19 @@ index f8be896..2c14eba 100644
 +# AUTODOCS_PM  = $(wildcard $(srcdir)/../../src/*/*.pm)
 +# include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-dirinstall.spec.in b/yast2-dirinstall.spec.in
-index 23e001e..d6378d8 100644
+index 23e001e..c6e1a4b 100644
 --- a/yast2-dirinstall.spec.in
 +++ b/yast2-dirinstall.spec.in
-@@ -41,7 +41,7 @@ directory.
+@@ -23,6 +23,8 @@ Provides:	/usr/share/YaST2/clients/dirinstall.ycp
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Installation into Directory
+ 
+ %description
+@@ -41,7 +43,7 @@ directory.
  %defattr(-,root,root)
  %dir @yncludedir@/dirinstall
  @yncludedir@/dirinstall/*

--- a/patches/dns-server.patch
+++ b/patches/dns-server.patch
@@ -2893,10 +2893,19 @@ index 5698a69..0000000
 -/* EOF */
 -}
 diff --git a/yast2-dns-server.spec.in b/yast2-dns-server.spec.in
-index cc654b2..12c59ac 100644
+index cc654b2..ff4f7b7 100644
 --- a/yast2-dns-server.spec.in
 +++ b/yast2-dns-server.spec.in
-@@ -50,8 +50,8 @@ This package contains the YaST2 component for DNS server configuration.
+@@ -33,6 +33,8 @@ Requires:	yast2 >= 2.17.8
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - DNS Server Configuration
+ 
+ %description
+@@ -50,8 +52,8 @@ This package contains the YaST2 component for DNS server configuration.
  %defattr(-,root,root)
  %dir @yncludedir@/dns-server
  @yncludedir@/dns-server/*

--- a/patches/drbd.patch
+++ b/patches/drbd.patch
@@ -37,10 +37,19 @@ index f5c46d3..5e7eb23 100644
  		"startup_conf",
  		"global_conf",
 diff --git a/yast2-drbd.spec.in b/yast2-drbd.spec.in
-index 70d1f7b..c79b0e1 100644
+index 70d1f7b..878b2e3 100644
 --- a/yast2-drbd.spec.in
 +++ b/yast2-drbd.spec.in
-@@ -30,7 +30,7 @@ Authors:
+@@ -6,6 +6,8 @@ Group:          System/YaST
+ BuildRequires:  perl-XML-Writer ruby rubygem-racc update-desktop-files yast2 yast2-devtools yast2-testsuite
+ Requires:       yast2 
+ BuildArch:      noarch
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:        YaST2 - DRBD Configuration
+ 
+ %description
+@@ -30,7 +32,7 @@ Authors:
  %files
  %defattr(-,root,root)
  @yncludedir@/drbd/

--- a/patches/fcoe-client.patch
+++ b/patches/fcoe-client.patch
@@ -10,10 +10,19 @@ index c6064ce..37172fc 100644
 +
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-fcoe-client.spec.in b/yast2-fcoe-client.spec.in
-index 44e9242..9c6e173 100644
+index 44e9242..876ab50 100644
 --- a/yast2-fcoe-client.spec.in
 +++ b/yast2-fcoe-client.spec.in
-@@ -26,9 +26,9 @@ Ethernet (FCoE) configuration.
+@@ -8,6 +8,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Configuration of Fibre Channel over Ethernet
+ 
+ %description
+@@ -26,9 +28,9 @@ Ethernet (FCoE) configuration.
  %defattr(-,root,root)
  %dir @yncludedir@/fcoe-client
  @yncludedir@/fcoe-client/*

--- a/patches/fingerprint-reader.patch
+++ b/patches/fingerprint-reader.patch
@@ -31,10 +31,19 @@ index 6233695..96989d4 100644
 +
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-fingerprint-reader.spec.in b/yast2-fingerprint-reader.spec.in
-index bcceba7..0788492 100644
+index bcceba7..e3a0b59 100644
 --- a/yast2-fingerprint-reader.spec.in
 +++ b/yast2-fingerprint-reader.spec.in
-@@ -28,8 +28,8 @@ thinkfinger library.
+@@ -10,6 +10,8 @@ BuildRequires:	doxygen gcc-c++ yast2-core-devel perl-XML-Writer update-desktop-f
+ 
+ Conflicts:	yast2-hardware-detection < 2.15.7
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Fingerprint Reader Configuration
+ 
+ %description
+@@ -28,8 +30,8 @@ thinkfinger library.
  %defattr(-,root,root)
  %dir @yncludedir@/fingerprint-reader
  @yncludedir@/fingerprint-reader/*

--- a/patches/firewall.patch
+++ b/patches/firewall.patch
@@ -59,3 +59,16 @@ index ccbb1a4..039e8a9 100644
  
      include "firewall/helps.ycp";
  
+diff --git a/yast2-firewall.spec.in b/yast2-firewall.spec.in
+index d1c1669..c9097f0 100644
+--- a/yast2-firewall.spec.in
++++ b/yast2-firewall.spec.in
+@@ -20,6 +20,8 @@ Obsoletes:	yast2-trans-firewall
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Firewall Configuration
+ 
+ %description

--- a/patches/firstboot.patch
+++ b/patches/firstboot.patch
@@ -136,10 +136,19 @@ index 671b84b..0000000
 -    return ret;
 -}
 diff --git a/yast2-firstboot.spec.in b/yast2-firstboot.spec.in
-index b0a1cd5..a2dab07 100644
+index b0a1cd5..8a44fb3 100644
 --- a/yast2-firstboot.spec.in
 +++ b/yast2-firstboot.spec.in
-@@ -53,10 +53,10 @@ mkdir -p $RPM_BUILD_ROOT/usr/share/firstboot/scripts
+@@ -20,6 +20,8 @@ Requires:	yast2-installation >= 2.19.0
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Initial System Configuration
+ PreReq:         %fillup_prereq
+ 
+@@ -53,10 +55,10 @@ mkdir -p $RPM_BUILD_ROOT/usr/share/firstboot/scripts
  %dir @ystartupdir@/startup/Firstboot-Stage
  @ystartupdir@/startup/Firstboot-Stage/*
  @ystartupdir@/startup/YaST2.Firstboot

--- a/patches/ftp-server.patch
+++ b/patches/ftp-server.patch
@@ -256,10 +256,19 @@ index 8fc5f60..540d97a 100644
                   if (Service::Enabled("vsftpd"))
                      Service::Disable("vsftpd");
 diff --git a/yast2-ftp-server.spec.in b/yast2-ftp-server.spec.in
-index 896a8c7..a3a401d 100644
+index 896a8c7..b5486fd 100644
 --- a/yast2-ftp-server.spec.in
 +++ b/yast2-ftp-server.spec.in
-@@ -28,8 +28,8 @@ configure two daemons: pure-ftpd and vsftpd.
+@@ -10,6 +10,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - FTP configuration
+ 
+ %description
+@@ -28,8 +30,8 @@ configure two daemons: pure-ftpd and vsftpd.
  %defattr(-,root,root)
  %dir @yncludedir@/ftp-server
  @yncludedir@/ftp-server/*

--- a/patches/hardware-detection.patch
+++ b/patches/hardware-detection.patch
@@ -69,3 +69,16 @@ index 78aebd5..f8da694 100644
 -EXTRA_DIST = *.ycp *.out *.err runtest.sh
 +EXTRA_DIST = *.rb *.out *.err runtest.sh
  
+diff --git a/yast2-hardware-detection.spec.in b/yast2-hardware-detection.spec.in
+index 3f57467..baabf59 100644
+--- a/yast2-hardware-detection.spec.in
++++ b/yast2-hardware-detection.spec.in
+@@ -22,6 +22,8 @@ BuildRequires:	openssl-devel
+ BuildRequires:	hwinfo-devel
+ # we check for hwinfo
+ BuildRequires:	pkg-config
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Hardware Detection Interface
+ # hwinfo-13.38: hw_fingerprint
+ Requires:       hwinfo >= 13.38

--- a/patches/heartbeat.patch
+++ b/patches/heartbeat.patch
@@ -57,10 +57,10 @@ index 4d29b98..c049388 100644
  include "heartbeat/helps.ycp";
  include "heartbeat/common.ycp";
 diff --git a/src/include/heartbeat/log_conf.ycp b/src/include/heartbeat/log_conf.ycp
-index 1302d3a..8b2d23c 100644
+index 1302d3a..e15de3c 100644
 --- a/src/include/heartbeat/log_conf.ycp
 +++ b/src/include/heartbeat/log_conf.ycp
-@@ -93,7 +92,9 @@ term timeouts_conf_getDialog()
+@@ -93,7 +93,9 @@ term timeouts_conf_getDialog()
  
  any ConfigureTimeoutsDialog () {
  
@@ -71,7 +71,7 @@ index 1302d3a..8b2d23c 100644
      
      my_SetContents("timeouts_conf", timeouts_conf_getDialog());
      
-@@ -119,7 +120,9 @@ any ConfigureTimeoutsDialog () {
+@@ -119,7 +121,9 @@ any ConfigureTimeoutsDialog () {
  
  	if (ret == `next || ret == `back || contains(DIALOG, (string)ret)) {
  	
@@ -107,10 +107,19 @@ index ba90cfe..01014ae 100644
  include "heartbeat/helps.ycp";
  include "heartbeat/common.ycp";
 diff --git a/yast2-heartbeat.spec.in b/yast2-heartbeat.spec.in
-index 6193558..f3044f6 100644
+index 6193558..77ab24d 100644
 --- a/yast2-heartbeat.spec.in
 +++ b/yast2-heartbeat.spec.in
-@@ -25,8 +25,7 @@ YaST-Module to configure heartbeat
+@@ -8,6 +8,8 @@ Requires:	yast2 >= 2.21.22
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - High Availability Configuration
+ 
+ %description
+@@ -25,8 +27,7 @@ YaST-Module to configure heartbeat
  %defattr(-,root,root)
  %dir @yncludedir@/heartbeat
  @yncludedir@/heartbeat/*

--- a/patches/hpc.patch
+++ b/patches/hpc.patch
@@ -32,10 +32,10 @@ index 2129f06..a2999af 100644
  
  
 diff --git a/yast2-hpc.spec.in b/yast2-hpc.spec.in
-index 3a404d6..c6ee79a 100644
+index 3a404d6..5a3c22f 100644
 --- a/yast2-hpc.spec.in
 +++ b/yast2-hpc.spec.in
-@@ -1,6 +1,11 @@
+@@ -1,10 +1,17 @@
  @HEADER-COMMENT@
  
 -# neededforbuild  yast2-devel-packages yast2 gpp libgpp
@@ -48,7 +48,13 @@ index 3a404d6..c6ee79a 100644
  
  @HEADER@
  Requires:	yast2
-@@ -23,8 +28,9 @@ Summary:	-
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	-
+ 
+ %description
+@@ -23,8 +30,9 @@ Summary:	-
  @moduledir@/*
  %dir @yncludedir@/hpc
  @yncludedir@/hpc/*

--- a/patches/http-server.patch
+++ b/patches/http-server.patch
@@ -87,10 +87,19 @@ index ed077e7..42be13e 100644
     * Sequention used for determining on which ip adresses and port apache2 will listen and if firewall is enebled
     * whether to open firewall on this port.
 diff --git a/yast2-http-server.spec.in b/yast2-http-server.spec.in
-index 2821125..f6c5e17 100644
+index 2821125..bcf9798 100644
 --- a/yast2-http-server.spec.in
 +++ b/yast2-http-server.spec.in
-@@ -30,8 +30,8 @@ configuration.
+@@ -11,6 +11,8 @@ Requires:       yast2 >= 2.21.22
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - HTTP Server Configuration
+ 
+ %description
+@@ -30,8 +32,8 @@ configuration.
  %dir @yncludedir@/http-server
  @schemadir@/autoyast/rnc/http-server.rnc
  @yncludedir@/http-server/*

--- a/patches/inetd.patch
+++ b/patches/inetd.patch
@@ -24,10 +24,19 @@ index 8e1465e..e9aa7f9 100644
    $[
      "comment" : " admind: admin daemon for thin clients\n uses ident and host name lookups for authentication\n security: weak authentication, just enough for thin clients\n client: adminc.pl\n default config file: /etc/opt/SLES/POS/admind.conf\n",
 diff --git a/yast2-inetd.spec.in b/yast2-inetd.spec.in
-index 74e1dd3..9274beb 100644
+index 74e1dd3..5389b0e 100644
 --- a/yast2-inetd.spec.in
 +++ b/yast2-inetd.spec.in
-@@ -35,10 +35,9 @@ The YaST2 component for configuring the inetd and xinetd daemons.
+@@ -18,6 +18,8 @@ Obsoletes:	yast2-trans-inet y2t_inet
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Network Services Configuration
+ 
+ %description
+@@ -35,10 +37,9 @@ The YaST2 component for configuring the inetd and xinetd daemons.
  %defattr(-,root,root)
  %dir @yncludedir@/inetd
  @yncludedir@/inetd/*

--- a/patches/installation.patch
+++ b/patches/installation.patch
@@ -121,10 +121,19 @@ index 0689035..66b2263 100644
      });
  
 diff --git a/yast2-installation.spec.in b/yast2-installation.spec.in
-index 2ff4767..fb583a0 100644
+index 2ff4767..adb6c00 100644
 --- a/yast2-installation.spec.in
 +++ b/yast2-installation.spec.in
-@@ -167,9 +167,8 @@ install -m 644 %{SOURCE2} %{buildroot}%{_unitdir}
+@@ -3,6 +3,8 @@
+ @HEADER@
+ Group:          System/YaST
+ License:        GPL-2.0
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:        YaST2 - Installation Parts
+ 
+ Source1:	YaST2-Second-Stage.service
+@@ -167,9 +169,8 @@ install -m 644 %{SOURCE2} %{buildroot}%{_unitdir}
  %{_unitdir}/YaST2-Second-Stage.service
  %{_unitdir}/YaST2-Firstboot.service
  

--- a/patches/instserver.patch
+++ b/patches/instserver.patch
@@ -20,10 +20,19 @@ index 93ce8ad..1d261db 100644
 +
  EXTRA_DIST = $(apacheconf_DATA) 
 diff --git a/yast2-instserver.spec.in b/yast2-instserver.spec.in
-index e452ea7..7502c98 100644
+index e452ea7..d8f6f7d 100644
 --- a/yast2-instserver.spec.in
 +++ b/yast2-instserver.spec.in
-@@ -31,7 +31,7 @@ NFS sources are supported.
+@@ -12,6 +12,8 @@ Requires:	yast2-slp
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Installation Server Configuration and Management
+ 
+ %description
+@@ -31,7 +33,7 @@ NFS sources are supported.
  %defattr(-,root,root)
  %dir @yncludedir@/instserver
  @yncludedir@/instserver/*

--- a/patches/irda.patch
+++ b/patches/irda.patch
@@ -22,10 +22,19 @@ index 2a6f678..6c072bd 100644
 +# TODO autodocs temporarily off
 +# include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-irda.spec.in b/yast2-irda.spec.in
-index 6390d36..9856e2f 100644
+index 6390d36..a00744e 100644
 --- a/yast2-irda.spec.in
 +++ b/yast2-irda.spec.in
-@@ -28,7 +28,7 @@ stack.
+@@ -10,6 +10,8 @@ Requires:	yast2 >= 2.21.22
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Infra-Red (IrDA) Access Configuration
+ 
+ %description
+@@ -28,7 +30,7 @@ stack.
  %defattr(-,root,root)
  %dir @yncludedir@/irda
  @yncludedir@/irda/*

--- a/patches/iscsi-client.patch
+++ b/patches/iscsi-client.patch
@@ -70,10 +70,19 @@ index 8c49b17..52fb8e9 100644
  		// delete (logout from) connected target
  		record = setRecord();
 diff --git a/yast2-iscsi-client.spec.in b/yast2-iscsi-client.spec.in
-index d945497..f4475c1 100644
+index d945497..c67d5a1 100644
 --- a/yast2-iscsi-client.spec.in
 +++ b/yast2-iscsi-client.spec.in
-@@ -35,9 +35,9 @@ client.
+@@ -17,6 +17,8 @@ Requires:       yast2 >= 2.21.22
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - iSCSI Client Configuration
+ 
+ %description
+@@ -35,9 +37,9 @@ client.
  %defattr(-,root,root)
  %dir @yncludedir@/iscsi-client
  @yncludedir@/iscsi-client/*

--- a/patches/iscsi-lio-server.patch
+++ b/patches/iscsi-lio-server.patch
@@ -60,10 +60,19 @@ index 5539378..8f476e9 100644
  string curr_target = "";
  integer curr_tpg = 1;
 diff --git a/yast2-iscsi-lio-server.spec.in b/yast2-iscsi-lio-server.spec.in
-index 0df1e82..8d1c915 100644
+index 0df1e82..b2ff62e 100644
 --- a/yast2-iscsi-lio-server.spec.in
 +++ b/yast2-iscsi-lio-server.spec.in
-@@ -31,8 +31,8 @@ This package contains configuration of iSCSI LIO target
+@@ -14,6 +14,8 @@ Requires:       yast2 >= 2.21.22
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	Configuration of iSCSI LIO target
+ 
+ %description
+@@ -31,8 +33,8 @@ This package contains configuration of iSCSI LIO target
  %defattr(-,root,root)
  %dir @yncludedir@/iscsi-lio-server
  @yncludedir@/iscsi-lio-server/*

--- a/patches/iscsi-server.patch
+++ b/patches/iscsi-server.patch
@@ -81,10 +81,19 @@ index 1141380..b2aee43 100644
  import "Wizard";
  
 diff --git a/yast2-iscsi-server.spec.in b/yast2-iscsi-server.spec.in
-index 94a45c6..7f968a1 100644
+index 94a45c6..743862d 100644
 --- a/yast2-iscsi-server.spec.in
 +++ b/yast2-iscsi-server.spec.in
-@@ -30,8 +30,8 @@ Configuration of iSCSI target
+@@ -13,6 +13,8 @@ Requires:       yast2 >= 2.21.22
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Configuration of iSCSI target
+ 
+ %description
+@@ -30,8 +32,8 @@ Configuration of iSCSI target
  %defattr(-,root,root)
  %dir @yncludedir@/iscsi-server
  @yncludedir@/iscsi-server/*

--- a/patches/isns.patch
+++ b/patches/isns.patch
@@ -34,7 +34,7 @@ index 309ade0..244253d 100644
  // store current here
  string current_tab = "service";
 diff --git a/src/include/isns/widgets.ycp b/src/include/isns/widgets.ycp
-index 8402786..5017864 100644
+index 3cbab5e..2e5d255 100644
 --- a/src/include/isns/widgets.ycp
 +++ b/src/include/isns/widgets.ycp
 @@ -5,6 +5,7 @@ import "Label";
@@ -46,10 +46,19 @@ index 8402786..5017864 100644
  string address = "";  //global
  
 diff --git a/yast2-isns.spec.in b/yast2-isns.spec.in
-index 6803626..08f3dd8 100644
+index 6803626..c46af21 100644
 --- a/yast2-isns.spec.in
 +++ b/yast2-isns.spec.in
-@@ -24,10 +24,9 @@ Summary:	Configuration of isns
+@@ -7,6 +7,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	Configuration of isns
+ 
+ %description
+@@ -24,10 +26,9 @@ Summary:	Configuration of isns
  %defattr(-,root,root)
  %dir @yncludedir@/isns
  @yncludedir@/isns/*

--- a/patches/kdump.patch
+++ b/patches/kdump.patch
@@ -34,7 +34,7 @@ index 9454e58..35c4a63 100644
 +
 +# include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/src/include/kdump/uifunctions.ycp b/src/include/kdump/uifunctions.ycp
-index 61fa93d..0b16eb8 100644
+index 61fa93d..8e02d7c 100644
 --- a/src/include/kdump/uifunctions.ycp
 +++ b/src/include/kdump/uifunctions.ycp
 @@ -17,6 +17,8 @@ import "Service";
@@ -47,10 +47,19 @@ index 61fa93d..0b16eb8 100644
      // EXAMPLE FUNCTIONS
  /*
 diff --git a/yast2-kdump.spec.in b/yast2-kdump.spec.in
-index 01bcdc8..9968a41 100644
+index 01bcdc8..1b74d21 100644
 --- a/yast2-kdump.spec.in
 +++ b/yast2-kdump.spec.in
-@@ -29,8 +29,8 @@ Configuration of kdump
+@@ -12,6 +12,8 @@ Recommends:     makedumpfile
+ BuildRequires:	yast2 >= 2.21.22
+ BuildRequires: yast2-packager >= 2.17.24
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	Configuration of kdump
+ 
+ %description
+@@ -29,8 +31,8 @@ Configuration of kdump
  %defattr(-,root,root)
  %dir @yncludedir@/kdump
  @yncludedir@/kdump/*

--- a/patches/kerberos-client.patch
+++ b/patches/kerberos-client.patch
@@ -22,10 +22,19 @@ index 2a6f678..9de7be0 100644
 +
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-kerberos-client.spec.in b/yast2-kerberos-client.spec.in
-index c63921e..a55237a 100644
+index c63921e..680b1c2 100644
 --- a/yast2-kerberos-client.spec.in
 +++ b/yast2-kerberos-client.spec.in
-@@ -30,16 +30,15 @@ Kerberos server will be used for user authentication.
+@@ -14,6 +14,8 @@ Requires:	yast2 >= 2.21.22
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Kerberos Client Configuration
+ 
+ %description
+@@ -30,16 +32,15 @@ Kerberos server will be used for user authentication.
  
  %files
  %defattr(-,root,root)

--- a/patches/kerberos-server.patch
+++ b/patches/kerberos-server.patch
@@ -35,10 +35,19 @@ index 64a5036..74b6629 100644
  import "Confirm";
  import "KerberosServer";
 diff --git a/yast2-kerberos-server.spec.in b/yast2-kerberos-server.spec.in
-index 1c43fd4..98e22c3 100644
+index 1c43fd4..c8743f0 100644
 --- a/yast2-kerberos-server.spec.in
 +++ b/yast2-kerberos-server.spec.in
-@@ -28,7 +28,7 @@ Control Center.
+@@ -10,6 +10,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Kerberos Server Configuration
+ 
+ %description
+@@ -28,7 +30,7 @@ Control Center.
  %defattr(-,root,root)
  %dir @yncludedir@/kerberos-server
  @yncludedir@/kerberos-server/*

--- a/patches/ldap-client.patch
+++ b/patches/ldap-client.patch
@@ -739,10 +739,19 @@ index 76100cd..e4322d9 100644
  	}
  	if (result == `ok)
 diff --git a/yast2-ldap-client.spec.in b/yast2-ldap-client.spec.in
-index 32deeaf..0b9564c 100644
+index 32deeaf..23afbfe 100644
 --- a/yast2-ldap-client.spec.in
 +++ b/yast2-ldap-client.spec.in
-@@ -50,9 +50,9 @@ OpenLDAP server will be used for user authentication.
+@@ -27,6 +27,8 @@ Obsoletes:	yast2-trans-ldap_client
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - LDAP Client Configuration
+ 
+ %description
+@@ -50,9 +52,9 @@ OpenLDAP server will be used for user authentication.
  @desktopdir@/ldap_browser.desktop
  %dir @yncludedir@/ldap
  @yncludedir@/ldap/*

--- a/patches/ldap-server.patch
+++ b/patches/ldap-server.patch
@@ -99,10 +99,19 @@ index fa64d62..5a5347e 100644
      import "Wizard";
  
 diff --git a/yast2-ldap-server.spec.in b/yast2-ldap-server.spec.in
-index f289990..56a6016 100644
+index f289990..12df00f 100644
 --- a/yast2-ldap-server.spec.in
 +++ b/yast2-ldap-server.spec.in
-@@ -36,9 +36,9 @@ rm -f $RPM_BUILD_ROOT/@plugindir@/libpy2ag_slapdconfig.so
+@@ -11,6 +11,8 @@ Requires:       yast2-users >= 2.22.3
+ 
+ # Wizard::SetDesktopTitleAndIcon
+ Requires:       yast2 >= 2.21.22
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - OpenLDAP Server Configuration
+ 
+ %description
+@@ -36,9 +38,9 @@ rm -f $RPM_BUILD_ROOT/@plugindir@/libpy2ag_slapdconfig.so
  %dir @yncludedir@/ldap-server
  %dir @moduledir@/YaPI
  @yncludedir@/ldap-server/*

--- a/patches/live-installer.patch
+++ b/patches/live-installer.patch
@@ -22,10 +22,19 @@ index 1b55e6e..0c9cbf9 100644
 +
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-live-installer.spec.in b/yast2-live-installer.spec.in
-index bff3e12..f739d90 100644
+index bff3e12..acd91b3 100644
 --- a/yast2-live-installer.spec.in
 +++ b/yast2-live-installer.spec.in
-@@ -32,7 +32,7 @@ hard disk of the computer.
+@@ -16,6 +16,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Installation from Live Media
+ 
+ %description
+@@ -32,7 +34,7 @@ hard disk of the computer.
  
  %files
  %defattr(-,root,root)

--- a/patches/lxc.patch
+++ b/patches/lxc.patch
@@ -22,10 +22,19 @@ index a58f723..4206737 100644
  include "lxc/helps.ycp";
  
 diff --git a/yast2-lxc.spec.in b/yast2-lxc.spec.in
-index 11e214c..844928a 100644
+index 11e214c..4b69d95 100644
 --- a/yast2-lxc.spec.in
 +++ b/yast2-lxc.spec.in
-@@ -23,7 +23,7 @@ Graphical management tool for Linux Containers (LXC)
+@@ -6,6 +6,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	Management tool for Linux Containers (LXC)
+ 
+ %description
+@@ -23,7 +25,7 @@ Graphical management tool for Linux Containers (LXC)
  %defattr(-,root,root)
  %dir @yncludedir@/lxc
  @yncludedir@/lxc/*

--- a/patches/mail.patch
+++ b/patches/mail.patch
@@ -146,10 +146,28 @@ index 1aa3e3b..05d8c27 100644
  boolean ReallyAbort() {
      return !MailServer::Modified() || Popup::ReallyAbort(true);
 diff --git a/yast2-mail.spec.in b/yast2-mail.spec.in
-index b85d006..1aedf1b 100644
+index b85d006..61eb746 100644
 --- a/yast2-mail.spec.in
 +++ b/yast2-mail.spec.in
-@@ -44,7 +44,6 @@ Plugins for the YaST2 users module for enterprise mail server
+@@ -28,6 +28,8 @@ Provides:       yast2-mail-server = %{version}
+ Obsoletes:      yast2-mail-server <= %{version}
+ Conflicts:	aaa_base < 10.3
+ BuildArch:	noarch
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Mail Configuration
+ 
+ %description
+@@ -35,6 +37,8 @@ The YaST2 component for mail configuration. It handles Postfix, Cyrus,
+ Amavis and Fetchmail.
+ 
+ %package plugins
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Users/Group Plugins for the mail delivery configuration
+ Group:		System/YaST
+ Requires:       perl-NetxAP acl
+@@ -44,7 +48,6 @@ Plugins for the YaST2 users module for enterprise mail server
  configuration.
  
  @PREP@
@@ -157,7 +175,7 @@ index b85d006..1aedf1b 100644
  
  @BUILD@
  
-@@ -62,11 +61,9 @@ cp agents/MasterCFParser.pm src
+@@ -62,11 +65,9 @@ cp agents/MasterCFParser.pm src
  %dir @clientdir@
  @clientdir@/mail*
  %dir @moduledir@

--- a/patches/metapackage.patch
+++ b/patches/metapackage.patch
@@ -1,8 +1,17 @@
 diff --git a/yast2-metapackage-handler.spec.in b/yast2-metapackage-handler.spec.in
-index ba8e259..dba910c 100644
+index ba8e259..1b676b7 100644
 --- a/yast2-metapackage-handler.spec.in
 +++ b/yast2-metapackage-handler.spec.in
-@@ -88,10 +88,9 @@ fi
+@@ -35,6 +35,8 @@ Requires:	/usr/bin/xdg-su
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:			YaST2 - Easy Installation of Add-on RPMs using Metapackages
+ 
+ %description
+@@ -88,10 +90,9 @@ fi
  /sbin/OneClickInstallCLI
  /sbin/OCICLI
  %dir @clientdir@

--- a/patches/mouse.patch
+++ b/patches/mouse.patch
@@ -10,10 +10,19 @@ index 10187ee..7ec4a56 100644
 +# AUTODOCS_YCP=$(srcdir)/../../src/*.ycp $(srcdir)/../../src/*/*.ycp
 +# include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-mouse.spec.in b/yast2-mouse.spec.in
-index 441235f..145a434 100644
+index 441235f..023bad4 100644
 --- a/yast2-mouse.spec.in
 +++ b/yast2-mouse.spec.in
-@@ -41,7 +41,7 @@ rm -f $RPM_BUILD_ROOT@desktopdir@/mouse.desktop
+@@ -19,6 +19,8 @@ Provides:       y2t_inst-mouse
+ Obsoletes:      y2t_inst-mouse
+ # Mouse-related installation scripts were moved here
+ Conflicts:      yast2-installation < 2.18.2
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:        YaST2 - Mouse Configuration
+ 
+ %description
+@@ -41,7 +43,7 @@ rm -f $RPM_BUILD_ROOT@desktopdir@/mouse.desktop
  %dir @yncludedir@/mouse
  @yncludedir@/mouse/*
  @moduledir@/*

--- a/patches/multipath.patch
+++ b/patches/multipath.patch
@@ -183,10 +183,19 @@ index b9bce1d..e8a30cf 100644
 -
 +}
 diff --git a/yast2-multipath.spec.in b/yast2-multipath.spec.in
-index 07a0732..cf40490 100644
+index 07a0732..6b4e689 100644
 --- a/yast2-multipath.spec.in
 +++ b/yast2-multipath.spec.in
-@@ -29,11 +29,11 @@ You can configure your multipathed devices with this module.
+@@ -9,6 +9,8 @@ BuildRequires:	yast2-storage
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary: YaST2 - Multipath Configuration
+ 
+ %description
+@@ -29,11 +31,11 @@ You can configure your multipathed devices with this module.
  
  %files
  %defattr(-,root,root)

--- a/patches/network.patch
+++ b/patches/network.patch
@@ -142,10 +142,25 @@ index c29640e..1adbc3f 100644
  include "network/routines.ycp";
  include "network/widgets.ycp";
 diff --git a/yast2-network.spec.in b/yast2-network.spec.in
-index de9eec7..e8b2cbc 100644
+index de9eec7..885c977 100644
 --- a/yast2-network.spec.in
 +++ b/yast2-network.spec.in
-@@ -71,10 +71,9 @@ fi
+@@ -29,10 +29,14 @@ PreReq:         /bin/rm
+ # carrier detection
+ Conflicts:      yast2-core < 2.10.6
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:        YaST2 - Network Configuration
+ 
+ %package devel-doc
+ Group:          System/YaST
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:        YaST2 - Developer documentation for yast2-network
+ 
+ %description 
+@@ -71,10 +75,9 @@ fi
  @ybindir@/*
  @ydatadir@/*
  @yncludedir@/network

--- a/patches/nfs-client.patch
+++ b/patches/nfs-client.patch
@@ -13,10 +13,19 @@ index b3ffc5a..1fb0e86 100644
  htmldir = $(docdir)
  
 diff --git a/yast2-nfs-client.spec.in b/yast2-nfs-client.spec.in
-index 61316d7..73581a6 100644
+index facbd30..4ecb378 100644
 --- a/yast2-nfs-client.spec.in
 +++ b/yast2-nfs-client.spec.in
-@@ -46,13 +46,12 @@ file system access. It allows access to files on remote machines.
+@@ -26,6 +26,8 @@ Provides:       yast2-config-network:/usr/lib/YaST2/clients/lan_nfs_client.ycp
+ 
+ BuildArch:      noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:        YaST2 - NFS Configuration
+ Url:            http://en.opensuse.org/Portal:YaST
+ 
+@@ -46,13 +48,12 @@ file system access. It allows access to files on remote machines.
  %dir @yncludedir@/nfs
  @yncludedir@/nfs/*
  %dir @clientdir@

--- a/patches/nfs-server.patch
+++ b/patches/nfs-server.patch
@@ -29,10 +29,19 @@ index 2a6f678..9de7be0 100644
 +
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-nfs-server.spec.in b/yast2-nfs-server.spec.in
-index 80a0e70..ed328ce 100644
+index 1949add..1a14d0d 100644
 --- a/yast2-nfs-server.spec.in
 +++ b/yast2-nfs-server.spec.in
-@@ -42,11 +42,10 @@ Requires:       limal-nfs-server-perl
+@@ -14,6 +14,8 @@ Recommends:     nfs-kernel-server
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - NFS Server Configuration
+ 
+ %description
+@@ -42,11 +44,10 @@ Requires:       limal-nfs-server-perl
  %defattr(-,root,root)
  %dir @yncludedir@/nfs_server
  @yncludedir@/nfs_server/*

--- a/patches/nis-client.patch
+++ b/patches/nis-client.patch
@@ -39,10 +39,19 @@ index 2a6f678..4cb582c 100644
 +
 +# include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-nis-client.spec.in b/yast2-nis-client.spec.in
-index 8a34023..c31cb81 100644
+index 8a34023..0afab19 100644
 --- a/yast2-nis-client.spec.in
 +++ b/yast2-nis-client.spec.in
-@@ -35,10 +35,10 @@ yellow pages.
+@@ -18,6 +18,8 @@ Provides:	yast2-trans-nis
+ Obsoletes:	yast2-trans-nis
+ Provides:	yast2-config-network:/usr/lib/YaST2/clients/lan_ypclient.ycp
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Network Information Services (NIS, YP) Configuration
+ 
+ %description
+@@ -35,10 +37,10 @@ yellow pages.
  %files
  %defattr(-,root,root)
  %dir @yncludedir@/nis

--- a/patches/nis-server.patch
+++ b/patches/nis-server.patch
@@ -22,10 +22,19 @@ index 2a6f678..9de7be0 100644
 +
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-nis-server.spec.in b/yast2-nis-server.spec.in
-index 67be058..8e6d83a 100644
+index 67be058..992b216 100644
 --- a/yast2-nis-server.spec.in
 +++ b/yast2-nis-server.spec.in
-@@ -44,14 +44,13 @@ This package contains documentation for yast2-nis-server
+@@ -18,6 +18,8 @@ Obsoletes:	yast2-trans-nis-server
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Network Information Services (NIS) Server Configuration
+ 
+ %package devel-doc
+@@ -44,14 +46,13 @@ This package contains documentation for yast2-nis-server
  %files
  %defattr(-,root,root)
  %dir @yncludedir@/nis_server

--- a/patches/ntp-client.patch
+++ b/patches/ntp-client.patch
@@ -38,10 +38,19 @@ index 2a6f678..4cb582c 100644
 +
 +# include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-ntp-client.spec.in b/yast2-ntp-client.spec.in
-index 4b69c82..39f7e06 100644
+index 4b69c82..f479a2a 100644
 --- a/yast2-ntp-client.spec.in
 +++ b/yast2-ntp-client.spec.in
-@@ -34,11 +34,11 @@ This package contains the YaST2 component for NTP client configuration.
+@@ -17,6 +17,8 @@ Requires:       yast2-country-data
+ 
+ BuildArch:      noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:        YaST2 - NTP Client Configuration
+ 
+ %description
+@@ -34,11 +36,11 @@ This package contains the YaST2 component for NTP client configuration.
  %defattr(-,root,root)
  %dir @yncludedir@/ntp-client
  @yncludedir@/ntp-client/*

--- a/patches/online-update-configuration.patch
+++ b/patches/online-update-configuration.patch
@@ -11,10 +11,19 @@ index 36b4715..3897b5d 100644
  // module title
  string moduleTitle = _("Online Update Configuration");
 diff --git a/yast2-online-update-configuration.spec.in b/yast2-online-update-configuration.spec.in
-index 88dbcc1..b5e1488 100644
+index 88dbcc1..4d6976b 100644
 --- a/yast2-online-update-configuration.spec.in
 +++ b/yast2-online-update-configuration.spec.in
-@@ -55,9 +55,8 @@ Allows to configure automatic online update.
+@@ -34,6 +34,8 @@ BuildRequires:  yast2-pkg-bindings >= 2.17.20
+ BuildArch:      noarch
+ 
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:        Configuration of Online Update
+ 
+ %description
+@@ -55,9 +57,8 @@ Allows to configure automatic online update.
  %doc @docdir@
  %dir @yncludedir@/online-update-configuration
  @yncludedir@/online-update-configuration/*

--- a/patches/online-update.patch
+++ b/patches/online-update.patch
@@ -10,10 +10,19 @@ index 2a6f678..4cb582c 100644
 +
 +# include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-online-update.spec.in b/yast2-online-update.spec.in
-index 12e1cd3..b7e86da 100644
+index 12e1cd3..3e84f0d 100644
 --- a/yast2-online-update.spec.in
 +++ b/yast2-online-update.spec.in
-@@ -40,12 +40,11 @@ YaST control center.
+@@ -17,6 +17,8 @@ Provides:	yast2-trans-online-update y2t_online_update
+ Obsoletes:	yast2-trans-online-update y2t_online_update
+ BuildArchitectures:     noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:    	YaST2 - Online Update (YOU)
+ 
+ %description
+@@ -40,12 +42,11 @@ YaST control center.
  %files
  %defattr(-,root,root)
  @scrconfdir@/*.scr

--- a/patches/openvas-security-scanner.patch
+++ b/patches/openvas-security-scanner.patch
@@ -25,10 +25,19 @@ index 27bbcac..f6daf89 100644
  import "OpenvasSecurityScanner";
  
 diff --git a/yast2-openvas-security-scanner.spec.in b/yast2-openvas-security-scanner.spec.in
-index 7abed8e..4f07978 100644
+index 7abed8e..f488df5 100644
 --- a/yast2-openvas-security-scanner.spec.in
 +++ b/yast2-openvas-security-scanner.spec.in
-@@ -23,7 +23,7 @@ Summary:	Configuration of openvas-security-scanner
+@@ -6,6 +6,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	Configuration of openvas-security-scanner
+ 
+ %description
+@@ -23,7 +25,7 @@ Summary:	Configuration of openvas-security-scanner
  %defattr(-,root,root)
  %dir @yncludedir@/openvas-security-scanner
  @yncludedir@/openvas-security-scanner/*

--- a/patches/packager.patch
+++ b/patches/packager.patch
@@ -15,10 +15,26 @@ index f8be896..87a7241 100644
 +#AUTODOCS_PM  = $(wildcard $(srcdir)/../../src/*/*.pm)
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-packager.spec.in b/yast2-packager.spec.in
-index 6510846..076ab12 100644
+index 6510846..3777b63 100644
 --- a/yast2-packager.spec.in
 +++ b/yast2-packager.spec.in
-@@ -87,11 +87,10 @@ This package contains a client for searching packages in online repositories
+@@ -58,11 +58,15 @@ Obsoletes:	y2t_spkg y2t_inst-packages y2pkginf y2c_spkg
+ Provides:	yast2-trans-package-manager yast2-trans-inst-packages
+ Obsoletes:	yast2-trans-package-manager yast2-trans-inst-packages
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Package Library
+ 
+ %package webpin
+ 
+ Group:		System/YaST
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Webpin package search client
+ 
+ %description
+@@ -87,11 +91,10 @@ This package contains a client for searching packages in online repositories
  %dir @yncludedir@/packager
  @yncludedir@/checkmedia/*
  @yncludedir@/packager/*
@@ -33,7 +49,7 @@ index 6510846..076ab12 100644
  @desktopdir@/*.desktop
  @scrconfdir@/*
  @execcompdir@/servers_non_y2/ag_*
-@@ -99,6 +98,6 @@ This package contains a client for searching packages in online repositories
+@@ -99,6 +102,6 @@ This package contains a client for searching packages in online repositories
  
  %files webpin
  %defattr(-,root,root)

--- a/patches/pam.patch
+++ b/patches/pam.patch
@@ -10,3 +10,16 @@ index 2c8851b..4c23223 100644
 +# TODO FIXME: temporarily disabled
 +
 +#include $(top_srcdir)/autodocs-ycp.ami
+diff --git a/yast2-pam.spec.in b/yast2-pam.spec.in
+index 10ada1a..b70d3df 100644
+--- a/yast2-pam.spec.in
++++ b/yast2-pam.spec.in
+@@ -15,6 +15,8 @@ Obsoletes:	yast2-agent-pam-devel
+ 
+ BuildArchitectures:     noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - PAM Agent
+ 
+ %description

--- a/patches/phone-services.patch
+++ b/patches/phone-services.patch
@@ -25,10 +25,19 @@ index a708e92..4b93a56 100644
 +#AUTODOCS_YCP = $(srcdir)/../../src/*/*.ycp
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-phone-services.spec.in b/yast2-phone-services.spec.in
-index 14daa0e..73c6542 100644
+index 14daa0e..5cc23df 100644
 --- a/yast2-phone-services.spec.in
 +++ b/yast2-phone-services.spec.in
-@@ -27,8 +27,8 @@ services, for example fax and answering machines.
+@@ -9,6 +9,8 @@ Requires:       yast2 > 2.21.22
+ Requires:       yast2-users
+ BuildArchitectures:     noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Phone Services Configuration
+ 
+ %description
+@@ -27,8 +29,8 @@ services, for example fax and answering machines.
  %defattr(-,root,root)
  %dir @yncludedir@/phone-services
  @yncludedir@/phone-services/*

--- a/patches/pos-installation.patch
+++ b/patches/pos-installation.patch
@@ -1,8 +1,30 @@
+diff --git a/pos-installation/yast2-pos-installation.spec.in b/pos-installation/yast2-pos-installation.spec.in
+index 3ec00b7..53e7eea 100644
+--- a/pos-installation/yast2-pos-installation.spec.in
++++ b/pos-installation/yast2-pos-installation.spec.in
+@@ -6,6 +6,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	POS Installation and Upgrade
+ 
+ %description
 diff --git a/yast2-pos-installation.spec.in b/yast2-pos-installation.spec.in
-index 3ec00b7..4425a0d 100644
+index 3ec00b7..9e8d79f 100644
 --- a/yast2-pos-installation.spec.in
 +++ b/yast2-pos-installation.spec.in
-@@ -23,9 +23,8 @@ mkdir -p "$RPM_BUILD_ROOT"/etc/SLEPOS
+@@ -6,6 +6,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	POS Installation and Upgrade
+ 
+ %description
+@@ -23,9 +25,8 @@ mkdir -p "$RPM_BUILD_ROOT"/etc/SLEPOS
  
  %files
  %defattr(-,root,root)

--- a/patches/power-management.patch
+++ b/patches/power-management.patch
@@ -76,10 +76,19 @@ index 4c44712..9dcef54 100644
    * Handler for command line interface
    * @param options map options from the command line
 diff --git a/yast2-power-management.spec.in b/yast2-power-management.spec.in
-index 145f877..45cd61d 100644
+index 145f877..e5e6e62 100644
 --- a/yast2-power-management.spec.in
 +++ b/yast2-power-management.spec.in
-@@ -28,8 +28,8 @@ configuration.
+@@ -10,6 +10,8 @@ BuildArchitectures: noarch
+ # .etc.policykit agent
+ Requires:	yast2 >= 2.14.7
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Power Management Configuration
+ 
+ %description
+@@ -28,8 +30,8 @@ configuration.
  %defattr(-,root,root)
  %dir @yncludedir@/power-management
  @yncludedir@/power-management/*

--- a/patches/printer.patch
+++ b/patches/printer.patch
@@ -153,10 +153,19 @@ index 253eff4..dc1bfd2 100644
      case(`serial):
            string serial_device_node = (string)UI::QueryWidget( `serial_device_node, `Value );
 diff --git a/yast2-printer.spec.in b/yast2-printer.spec.in
-index 27b37f2..2d9e285 100644
+index 27b37f2..22ffe31 100644
 --- a/yast2-printer.spec.in
 +++ b/yast2-printer.spec.in
-@@ -55,7 +55,7 @@ chmod 755 %{my_requires}
+@@ -18,6 +18,8 @@ Requires:       yast2 >= 2.16.12
+ # which are pulled in by Autoreqprov because of the basicadd_displaytest tool:
+ %define my_requires /tmp/my-requires
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:        YaST2 - Printer Configuration
+ License:        GPL-2.0
+ Group:          Documentation/SUSE
+@@ -55,7 +57,7 @@ chmod 755 %{my_requires}
  %defattr(-,root,root)
  %dir @yncludedir@/printer
  @desktopdir@/printer.desktop

--- a/patches/product-creator.patch
+++ b/patches/product-creator.patch
@@ -61,10 +61,19 @@ index f1943dd..59885c1 100644
      textdomain "product-creator";
  
 diff --git a/yast2-product-creator.spec.in b/yast2-product-creator.spec.in
-index 87e9116..1d31e87 100644
+index 87e9116..47fdf27 100644
 --- a/yast2-product-creator.spec.in
 +++ b/yast2-product-creator.spec.in
-@@ -53,11 +53,10 @@ install -d $RPM_BUILD_ROOT/var/lib/YaST2/product-creator
+@@ -31,6 +31,8 @@ Recommends:	kiwi-config-openSUSE
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Module for Creating New Products
+ 
+ %description
+@@ -53,11 +55,10 @@ install -d $RPM_BUILD_ROOT/var/lib/YaST2/product-creator
  %defattr(-,root,root)
  %dir @yncludedir@/product-creator
  @yncludedir@/product-creator/*

--- a/patches/profile-manager.patch
+++ b/patches/profile-manager.patch
@@ -27,10 +27,19 @@ index 86f42b0..ddde8e7 100644
 +#include $(top_srcdir)/autodocs-ycp.ami
  
 diff --git a/yast2-profile-manager.spec.in b/yast2-profile-manager.spec.in
-index b8e6a4e..ada8309 100644
+index b8e6a4e..f5c6375 100644
 --- a/yast2-profile-manager.spec.in
 +++ b/yast2-profile-manager.spec.in
-@@ -28,10 +28,9 @@ profiles of your system configuration and switch between them.
+@@ -9,6 +9,8 @@ Requires:	yast2 >= 2.21.22
+ Requires:	 yast2-users
+ Requires:	scpm >= 0.9.4
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Profile Configuration
+ 
+ %description
+@@ -28,10 +30,9 @@ profiles of your system configuration and switch between them.
  %defattr(-,root,root)
  %dir @yncludedir@/profile-manager
  @yncludedir@/profile-manager/*

--- a/patches/proxy.patch
+++ b/patches/proxy.patch
@@ -21,10 +21,19 @@ index 5b3470c..d5925e8 100644
  
      Wizard::CreateDialog();
 diff --git a/yast2-proxy.spec.in b/yast2-proxy.spec.in
-index 09b83c7..53d134d 100644
+index 09b83c7..c2c852e 100644
 --- a/yast2-proxy.spec.in
 +++ b/yast2-proxy.spec.in
-@@ -33,9 +33,8 @@ This package contains the YaST2 component for proxy configuration.
+@@ -17,6 +17,8 @@ Conflicts:      yast2-network < 2.22.6
+ PreReq:         /bin/rm
+ BuildArch:      noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:        YaST2 - Proxy Configuration
+ Url:            http://en.opensuse.org/Portal:YaST
+ 
+@@ -33,9 +35,8 @@ This package contains the YaST2 component for proxy configuration.
  
  %files
  %defattr(-,root,root)

--- a/patches/rdp.patch
+++ b/patches/rdp.patch
@@ -40,10 +40,19 @@ index 2189d55..7fe38e7 100644
      string caption = _("Remote Administration");
  
 diff --git a/yast2-rdp.spec.in b/yast2-rdp.spec.in
-index 3e26290..0090126 100644
+index 3e26290..4645afb 100644
 --- a/yast2-rdp.spec.in
 +++ b/yast2-rdp.spec.in
-@@ -23,8 +23,8 @@ Summary:	Configuration of rdp
+@@ -6,6 +6,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	Configuration of rdp
+ 
+ %description
+@@ -23,8 +25,8 @@ Summary:	Configuration of rdp
  %defattr(-,root,root)
  %dir @yncludedir@/rdp
  @yncludedir@/rdp/*

--- a/patches/rear.patch
+++ b/patches/rear.patch
@@ -1,8 +1,17 @@
 diff --git a/yast2-rear.spec.in b/yast2-rear.spec.in
-index 6efa94c..03524bf 100644
+index 6efa94c..1819c36 100644
 --- a/yast2-rear.spec.in
 +++ b/yast2-rear.spec.in
-@@ -28,7 +28,7 @@ The YaST2 component for configuring Rear - Relax and Recover Backup
+@@ -10,6 +10,8 @@ Requires:       yast2-storage
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Rear - Relax and Recover
+ 
+ %description
+@@ -28,7 +30,7 @@ The YaST2 component for configuring Rear - Relax and Recover Backup
  %defattr(-,root,root)
  %dir @yncludedir@/rear
  @yncludedir@/rear/*

--- a/patches/registration.patch
+++ b/patches/registration.patch
@@ -21,10 +21,10 @@ index 0fcd3e0..e69de29 100644
 -
 -EXTRA_DIST = $(agent_SCRIPTS) $(scrconf_DATA)
 diff --git a/yast2-registration.spec.in b/yast2-registration.spec.in
-index a6554c2..ee05fcd 100644
+index a6554c2..2620a7a 100644
 --- a/yast2-registration.spec.in
 +++ b/yast2-registration.spec.in
-@@ -31,10 +31,12 @@ Requires(post): sed grep
+@@ -31,11 +31,15 @@ Requires(post): sed grep
  PreReq:         %fillup_prereq
  BuildRequires:  yast2 >= 2.23.13
  BuildRequires:  perl-XML-Writer update-desktop-files yast2-devtools yast2-packager yast2-testsuite
@@ -37,9 +37,12 @@ index a6554c2..ee05fcd 100644
 -Buildrequires:  PolicyKit-devel
 +Buildrequires:  polkit
  BuildArch:      noarch
++Requires:       yast2-ruby-bindings >= 1.0.0
++
  Summary:        YaST2 - Registration Module
  
-@@ -54,8 +56,8 @@ Authors:
+ Source1:        org.opensuse.yast.modules.ysr.policy
+@@ -54,8 +58,8 @@ Authors:
  
  @INSTALL@
  
@@ -50,7 +53,7 @@ index a6554c2..ee05fcd 100644
  
  
  @CLEAN@
-@@ -113,19 +115,18 @@ fi
+@@ -113,19 +117,18 @@ fi
  %files
  %defattr(-,root,root)
  %doc @docdir@

--- a/patches/reipl.patch
+++ b/patches/reipl.patch
@@ -34,10 +34,27 @@ index 83bbbd9..464185d 100644
  /**
   * Configure dialog
 diff --git a/yast2-reipl.spec.in b/yast2-reipl.spec.in
-index 490276d..8c2cfa3 100644
+index 490276d..45c35f6 100644
 --- a/yast2-reipl.spec.in
 +++ b/yast2-reipl.spec.in
-@@ -48,9 +48,8 @@ Module for loading IPL from running system on S/390
+@@ -21,14 +21,12 @@ PreReq:         %fillup_prereq
+ 
+ BuildArch:      noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:        YaST2 - IPL loader
+ License:        GPL-2.0
+ Group:          System/YaST
+ 
+-PreReq:         %fillup_prereq
+-
+-Summary:        YaST2 - IPL loader
+-Group:          System/YaST
+ 
+ %description
+ Module for loading IPL from running system on S/390
+@@ -48,9 +46,8 @@ Module for loading IPL from running system on S/390
  
  %files
  %defattr(-,root,root)

--- a/patches/restore.patch
+++ b/patches/restore.patch
@@ -24,10 +24,19 @@ index 2a6f678..9de7be0 100644
 +
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-restore.spec.in b/yast2-restore.spec.in
-index 15010fc..f7be7a6 100644
+index 15010fc..b1a0d4c 100644
 --- a/yast2-restore.spec.in
 +++ b/yast2-restore.spec.in
-@@ -35,10 +35,9 @@ Backup module.
+@@ -16,6 +16,8 @@ Requires:	yast2-bootloader
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - System Restore
+ 
+ %description
+@@ -35,10 +37,9 @@ Backup module.
  
  %dir @yncludedir@/restore
  @yncludedir@/restore/*

--- a/patches/runlevel.patch
+++ b/patches/runlevel.patch
@@ -53,10 +53,19 @@ index 0c65120..9377ff3 100644
  		}
  		else if (`clear_all == ret)
 diff --git a/yast2-runlevel.spec.in b/yast2-runlevel.spec.in
-index db65ebd..9b0fa86 100644
+index d8fdbd1..cd2b68a 100644
 --- a/yast2-runlevel.spec.in
 +++ b/yast2-runlevel.spec.in
-@@ -37,11 +37,10 @@ boot.
+@@ -16,6 +16,8 @@ Obsoletes:	yast2-config-runlevel
+ Provides:	yast2-trans-runlevel
+ Obsoletes:	yast2-trans-runlevel
+ BuildArchitectures:     noarch
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Runlevel Editor
+ 
+ %description
+@@ -37,11 +39,10 @@ boot.
  %dir @scrconfdir@
  @scrconfdir@/*.scr
  %dir @clientdir@

--- a/patches/s390.patch
+++ b/patches/s390.patch
@@ -25,10 +25,10 @@ index 7d55a84..7ce8d69 100644
 +#include $(top_srcdir)/autodocs-ycp.ami
  
 diff --git a/yast2-s390.spec.in b/yast2-s390.spec.in
-index 9f098e9..aa91cca 100644
+index 9f098e9..cb5012f 100644
 --- a/yast2-s390.spec.in
 +++ b/yast2-s390.spec.in
-@@ -5,7 +5,9 @@ Group:		System/YaST
+@@ -5,9 +5,13 @@ Group:		System/YaST
  License:        GPL-2.0
  BuildRequires:	docbook-xsl-stylesheets doxygen libxslt perl-XML-Writer sgml-skel update-desktop-files
  BuildRequires:	yast2 yast2-devtools yast2-testsuite yast2-users yast2-bootloader
@@ -38,8 +38,12 @@ index 9f098e9..aa91cca 100644
 +#ExclusiveArch:  s390 s390x
  Requires:       yast2 s390-tools
  
++Requires:       yast2-ruby-bindings >= 1.0.0
++
  Summary:	YaST2 - S/390 Specific Features Configuration
-@@ -26,7 +28,7 @@ S/390-specific features.
+ 
+ %description
+@@ -26,7 +30,7 @@ S/390-specific features.
  %defattr(-,root,root)
  %dir @yncludedir@/s390
  @yncludedir@/s390/*

--- a/patches/samba-client.patch
+++ b/patches/samba-client.patch
@@ -39,10 +39,19 @@ index 4128d71..ddde8e7 100644
 +#include $(top_srcdir)/autodocs-ycp.ami
  
 diff --git a/yast2-samba-client.spec.in b/yast2-samba-client.spec.in
-index 0dc5bb4..58e4d2f 100644
+index 0dc5bb4..a8c417e 100644
 --- a/yast2-samba-client.spec.in
 +++ b/yast2-samba-client.spec.in
-@@ -33,11 +33,10 @@ workgroup/domain and authentication against an SMB domain.
+@@ -15,6 +15,8 @@ Requires:       yast2 >= 2.21.22
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Samba Client Configuration
+ 
+ %description
+@@ -33,11 +35,10 @@ workgroup/domain and authentication against an SMB domain.
  %defattr(-,root,root)
  %dir @yncludedir@/samba-client
  @yncludedir@/samba-client/*

--- a/patches/samba-server.patch
+++ b/patches/samba-server.patch
@@ -446,10 +446,19 @@ index 71a7009..e69de29 100644
 -
 -include $(top_srcdir)/Makefile.am.common
 diff --git a/yast2-samba-server.spec.in b/yast2-samba-server.spec.in
-index 025c57d..2b064cf 100644
+index 025c57d..780108a 100644
 --- a/yast2-samba-server.spec.in
 +++ b/yast2-samba-server.spec.in
-@@ -41,8 +41,8 @@ configuration.
+@@ -23,6 +23,8 @@ Supplements:	samba
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Samba Server Configuration
+ 
+ %description
+@@ -41,8 +43,8 @@ configuration.
  %defattr(-,root,root)
  %dir @yncludedir@/samba-server
  @yncludedir@/samba-server/*

--- a/patches/scanner.patch
+++ b/patches/scanner.patch
@@ -10,10 +10,19 @@ index 2a6f678..9de7be0 100644
 +
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-scanner.spec.in b/yast2-scanner.spec.in
-index 625ac90..5dcb128 100644
+index 625ac90..6f09d12 100644
 --- a/yast2-scanner.spec.in
 +++ b/yast2-scanner.spec.in
-@@ -42,7 +42,7 @@ chmod 755 %{my_requires}
+@@ -8,6 +8,8 @@ Requires:	yast2
+ # which are pulled in by Autoreqprov because of the displaytest tool:
+ %define my_requires /tmp/my-requires
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Scanner Configuration
+ License:        GPL-2.0
+ 
+@@ -42,7 +44,7 @@ chmod 755 %{my_requires}
  %defattr(-,root,root)
  %dir @yncludedir@/scanner
  @yncludedir@/scanner/*

--- a/patches/security.patch
+++ b/patches/security.patch
@@ -21,10 +21,19 @@ index b54cdda..7b53634 100644
  /**
   * Adduser dialog
 diff --git a/yast2-security.spec.in b/yast2-security.spec.in
-index a60270e..1a9d44c 100644
+index a60270e..53cfa05 100644
 --- a/yast2-security.spec.in
 +++ b/yast2-security.spec.in
-@@ -43,8 +43,8 @@ fi
+@@ -19,6 +19,8 @@ Obsoletes:	yast2-trans-security y2t_sec
+ 
+ BuildArchitectures: noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Security Configuration
+ 
+ %description
+@@ -43,8 +45,8 @@ fi
  %dir @yncludedir@/security
  @yncludedir@/security/*
  @desktopdir@/security.desktop

--- a/patches/slp-server.patch
+++ b/patches/slp-server.patch
@@ -38,7 +38,7 @@ index 5004c0f..cc955c9 100644
  void initServerSettings(string key);
  symbol handleServerSettings(string key, map event );
 diff --git a/yast2-slp-server.spec.in b/yast2-slp-server.spec.in
-index 9d75923..f154f73 100644
+index 9d75923..5699f61 100644
 --- a/yast2-slp-server.spec.in
 +++ b/yast2-slp-server.spec.in
 @@ -4,7 +4,7 @@
@@ -50,7 +50,16 @@ index 9d75923..f154f73 100644
  
  # network needs Wizard::OpenCancelOKDialog()
  #  function from yast2-2.18.2
-@@ -31,8 +31,8 @@ SLP daemon.
+@@ -13,6 +13,8 @@ Requires:       yast2 >= 2.21.22
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 SLP Daemon Server Configuration
+ 
+ %description
+@@ -31,8 +33,8 @@ SLP daemon.
  %defattr(-,root,root)
  %dir @yncludedir@/slp-server
  @yncludedir@/slp-server/*

--- a/patches/slp.patch
+++ b/patches/slp.patch
@@ -10,10 +10,19 @@ index 2a6f678..9de7be0 100644
 +
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-slp.spec.in b/yast2-slp.spec.in
-index bbb0628..947c071 100644
+index bbb0628..cbbab3f 100644
 --- a/yast2-slp.spec.in
 +++ b/yast2-slp.spec.in
-@@ -31,7 +31,7 @@ Additionally, it offers a simple browser of SLP registered services.
+@@ -11,6 +11,8 @@ Requires: openslp
+ # Wizard::SetDesktopTitleAndIcon
+ Requires: yast2 >= 2.21.22
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - SLP Agent and Browser
+ 
+ %description
+@@ -31,7 +33,7 @@ Additionally, it offers a simple browser of SLP registered services.
  @plugindir@/libpy2ag_slp.so.*
  @plugindir@/libpy2ag_slp.so
  @plugindir@/libpy2ag_slp.la

--- a/patches/snapper.patch
+++ b/patches/snapper.patch
@@ -36,10 +36,19 @@ index 2cbc75e..17633f0 100644
 +
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-snapper.spec.in b/yast2-snapper.spec.in
-index c91664f..570f4a7 100644
+index c91664f..c91c855 100644
 --- a/yast2-snapper.spec.in
 +++ b/yast2-snapper.spec.in
-@@ -25,7 +25,7 @@ YaST module for accessing and managing btrfs system snapshots
+@@ -8,6 +8,8 @@ BuildRequires:	libsnapper-devel >= 0.0.11
+ BuildRequires:	yast2-core-devel >= 2.23.1
+ BuildRequires:	libtool doxygen gcc-c++ perl-XML-Writer
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST - file system snapshots review
+ 
+ %description
+@@ -25,7 +27,7 @@ YaST module for accessing and managing btrfs system snapshots
  %defattr(-,root,root)
  %dir @yncludedir@/snapper
  @yncludedir@/snapper/*

--- a/patches/sound.patch
+++ b/patches/sound.patch
@@ -36,10 +36,19 @@ index 0764d69..9ef8dbb 100644
 -SUBDIRS = doc src testsuite agents config
 +SUBDIRS =
 diff --git a/yast2-sound.spec.in b/yast2-sound.spec.in
-index 1b9ba31..a127a87 100644
+index 1b9ba31..c7ffd5f 100644
 --- a/yast2-sound.spec.in
 +++ b/yast2-sound.spec.in
-@@ -42,9 +42,9 @@ fi
+@@ -17,6 +17,8 @@ Obsoletes:	yast2-trans-sound yast2-trans-soundd y2c_snd y2t_snd y2t_sndd
+ Provides:	y2c_sparc y2c_sprc yast2-db-sound y2d_snd
+ Obsoletes:	y2c_sparc y2c_sprc yast2-db-sound y2d_snd
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Sound Configuration
+ 
+ %description
+@@ -42,9 +44,9 @@ fi
  
  # sound
  %dir @yncludedir@/sound
@@ -52,7 +61,7 @@ index 1b9ba31..a127a87 100644
  @desktopdir@/sound.desktop
  @desktopdir@/joystick.desktop
  @ybindir@/copyfonts
-@@ -57,7 +57,7 @@ fi
+@@ -57,7 +59,7 @@ fi
  
  # database
  @ydatadir@/sndcards.ycp

--- a/patches/squid.patch
+++ b/patches/squid.patch
@@ -49,10 +49,19 @@ index 5c90780..e70ce9c 100644
 +
 +# include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-squid.spec.in b/yast2-squid.spec.in
-index 7837bae..6476be6 100644
+index 7837bae..4080d13 100644
 --- a/yast2-squid.spec.in
 +++ b/yast2-squid.spec.in
-@@ -28,8 +28,8 @@ rm -rf %{buildroot}/@plugindir@/libpy2ag_squid.la
+@@ -9,6 +9,8 @@ BuildRequires: yast2-testsuite yast2-core-devel boost-devel gcc-c++ libtool
+ 
+ #BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	Configuration of squid
+ 
+ %description
+@@ -28,8 +30,8 @@ rm -rf %{buildroot}/@plugindir@/libpy2ag_squid.la
  %dir @yncludedir@/squid
  %config /etc/sysconfig/SuSEfirewall2.d/services/squid
  @yncludedir@/squid/*

--- a/patches/squidguard.patch
+++ b/patches/squidguard.patch
@@ -26,10 +26,19 @@ index d0e5f35..56cb5d0 100644
 +
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-squidguard.spec.in b/yast2-squidguard.spec.in
-index 5a0cf74..9b728ea 100644
+index 5a0cf74..bf97fd4 100644
 --- a/yast2-squidguard.spec.in
 +++ b/yast2-squidguard.spec.in
-@@ -23,9 +23,11 @@ Summary:	Configuration of squidguard
+@@ -6,6 +6,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ Requires:       squidGuard
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	Configuration of squidguard
+ 
+ %description
+@@ -23,9 +25,11 @@ Summary:	Configuration of squidguard
  %defattr(-,root,root)
  %dir @yncludedir@/squidguard
  @yncludedir@/squidguard/*

--- a/patches/sshd.patch
+++ b/patches/sshd.patch
@@ -1,5 +1,5 @@
 diff --git a/doc/Makefile.am b/doc/Makefile.am
-index f85d6ff..f30ecf6 100644
+index f85d6ff..ed7906a 100644
 --- a/doc/Makefile.am
 +++ b/doc/Makefile.am
 @@ -1,6 +1,7 @@
@@ -27,10 +27,19 @@ index 28e831e..af311ca 100644
  
  /* Finish */
 diff --git a/yast2-sshd.spec.in b/yast2-sshd.spec.in
-index 3cd820b..7c48733 100644
+index 3cd820b..5cf8ddf 100644
 --- a/yast2-sshd.spec.in
 +++ b/yast2-sshd.spec.in
-@@ -26,10 +26,9 @@ This package contains the YaST2 component for SSH server configuration.
+@@ -9,6 +9,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - SSH Server Configuration
+ 
+ %description
+@@ -26,10 +28,9 @@ This package contains the YaST2 component for SSH server configuration.
  %defattr(-,root,root)
  %dir @yncludedir@/sshd
  @yncludedir@/sshd/*

--- a/patches/storage.patch
+++ b/patches/storage.patch
@@ -2104,10 +2104,19 @@ index 39df374..c751218 100644
 +    include "helper1b.yh";
  }
 diff --git a/yast2-storage.spec.in b/yast2-storage.spec.in
-index 8ae9071..408d91a 100644
+index 8ae9071..4ab9e67 100644
 --- a/yast2-storage.spec.in
 +++ b/yast2-storage.spec.in
-@@ -47,26 +47,27 @@ rm -f $RPM_BUILD_ROOT/@plugindir@/libpy2StorageCallbacks.so
+@@ -23,6 +23,8 @@ Provides:	yast2-trans-inst-partitioning
+ Obsoletes:	yast2-trans-inst-partitioning
+ Provides:	y2t_inst-partitioning
+ Obsoletes:	y2t_inst-partitioning
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Storage Configuration
+ 
+ %description
+@@ -47,26 +49,27 @@ rm -f $RPM_BUILD_ROOT/@plugindir@/libpy2StorageCallbacks.so
  
  # storage
  %dir @yncludedir@/partitioning
@@ -2150,7 +2159,15 @@ index 8ae9071..408d91a 100644
  
  %doc %dir @docdir@
  %doc @docdir@/README*
-@@ -100,5 +101,6 @@ to develop a program using libstorage.
+@@ -91,6 +94,7 @@ rm -f $RPM_BUILD_ROOT/@plugindir@/libpy2StorageCallbacks.so
+ %package devel
+ Requires:	libstorage-devel = %(echo `rpm -q --queryformat '%{VERSION}' libstorage-devel`)
+ Requires:       libstdc++-devel yast2-storage = %version
++
+ Summary:        YaST2 - Storage Library Headers and Documentation
+ Group:          Development/Libraries/YaST
+ 
+@@ -100,5 +104,6 @@ to develop a program using libstorage.
  
  %files devel
  %defattr(-,root,root)

--- a/patches/sudo.patch
+++ b/patches/sudo.patch
@@ -26,10 +26,19 @@ index 2a519b9..4668e9b 100644
  htmldir = $(docdir)
  
 diff --git a/yast2-sudo.spec.in b/yast2-sudo.spec.in
-index 26b8cd0..5a28b96 100644
+index 26b8cd0..50df00a 100644
 --- a/yast2-sudo.spec.in
 +++ b/yast2-sudo.spec.in
-@@ -32,7 +32,7 @@ of users to run commands as root or other user.
+@@ -14,6 +14,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - sudo configuration
+ 
+ %description
+@@ -32,7 +34,7 @@ of users to run commands as root or other user.
  %defattr(-,root,root)
  %dir @yncludedir@/sudo
  @yncludedir@/sudo/*

--- a/patches/support.patch
+++ b/patches/support.patch
@@ -43,10 +43,19 @@ index 105e952..a3adbed 100644
  any OverviewDialog(){
  
 diff --git a/yast2-support.spec.in b/yast2-support.spec.in
-index 41404e7..ca203a6 100644
+index 41404e7..2e15828 100644
 --- a/yast2-support.spec.in
 +++ b/yast2-support.spec.in
-@@ -26,8 +26,8 @@ support in a standardized format.
+@@ -8,6 +8,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Support Inquiries
+ 
+ %description
+@@ -26,8 +28,8 @@ support in a standardized format.
  %defattr(-,root,root)
  %dir @yncludedir@/support
  @yncludedir@/support/*

--- a/patches/sysconfig.patch
+++ b/patches/sysconfig.patch
@@ -13,10 +13,19 @@ index fbc0358..e11ea30 100644
  htmldir = $(docdir)
  
 diff --git a/yast2-sysconfig.spec.in b/yast2-sysconfig.spec.in
-index 88bf07f..6b98a3e 100644
+index 88bf07f..595dc29 100644
 --- a/yast2-sysconfig.spec.in
 +++ b/yast2-sysconfig.spec.in
-@@ -33,10 +33,9 @@ information.
+@@ -15,6 +15,8 @@ Obsoletes:	y2c_rc_config yast2-config-rcconfig yast2-config-sysconfig
+ Provides:	yast2-trans-sysconfig yast2-trans-rcconfig y2t_rc_config
+ Obsoletes:	yast2-trans-sysconfig yast2-trans-rcconfig y2t_rc_config
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Sysconfig Editor
+ 
+ %description
+@@ -33,10 +35,9 @@ information.
  %defattr(-,root,root)
  %dir @yncludedir@/sysconfig
  @yncludedir@/sysconfig/*

--- a/patches/testsuite.patch
+++ b/patches/testsuite.patch
@@ -42,3 +42,16 @@ index 5596f82..f86f329 100644
  
  map READ = $[ "read" : $[ "path" : "read_result" ] ];
  map WRITE = $[ "write" : $[ "path" : true ] ];
+diff --git a/yast2-testsuite.spec.in b/yast2-testsuite.spec.in
+index 9c5c8b6..83e4fae 100644
+--- a/yast2-testsuite.spec.in
++++ b/yast2-testsuite.spec.in
+@@ -7,6 +7,8 @@ BuildRequires:	openslp-devel perl-XML-Writer popt-devel yast2-core-devel yast2-d
+ Requires:	expect dejagnu
+ # y2base -I includepath -M modulepath
+ Requires:	yast2-core >= 2.19.0
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Testsuite
+ 
+ BuildArchitectures: noarch

--- a/patches/tftp-server.patch
+++ b/patches/tftp-server.patch
@@ -10,10 +10,19 @@ index 2a6f678..9de7be0 100644
 +
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-tftp-server.spec.in b/yast2-tftp-server.spec.in
-index 96e62f9..2f20712 100644
+index 96e62f9..9b2e3b6 100644
 --- a/yast2-tftp-server.spec.in
 +++ b/yast2-tftp-server.spec.in
-@@ -33,7 +33,7 @@ network.
+@@ -14,6 +14,8 @@ Requires:	lsof
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - TFTP Server Configuration
+ 
+ %description
+@@ -33,7 +35,7 @@ network.
  %defattr(-,root,root)
  %dir @yncludedir@/tftp-server
  @yncludedir@/tftp-server/*

--- a/patches/transfer.patch
+++ b/patches/transfer.patch
@@ -27,3 +27,16 @@ index 35be7b7..e69de29 100644
 -EXTRA_DIST = $(module_DATA)
 -
 -include $(top_srcdir)/Makefile.am.common
+diff --git a/yast2-transfer.spec.in b/yast2-transfer.spec.in
+index 5a000da..4547ce7 100644
+--- a/yast2-transfer.spec.in
++++ b/yast2-transfer.spec.in
+@@ -7,6 +7,8 @@ BuildRequires:	curl-devel gcc-c++ perl-XML-Writer update-desktop-files yast2 yas
+ %if 0%{?suse_version} < 1220
+ BuildRequires:  libxcrypt-devel
+ %endif
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Agent for Various Transfer Protocols
+ Provides:	yast2-agent-curl yast2-agent-tftp yast2-agent-curl-devel yast2-agent-tftp-devel
+ Obsoletes:	yast2-agent-curl yast2-agent-tftp yast2-agent-curl-devel yast2-agent-tftp-devel

--- a/patches/tune.patch
+++ b/patches/tune.patch
@@ -64,10 +64,19 @@ index 204e23b..e69de29 100644
 -
 -include $(top_srcdir)/Makefile.am.common
 diff --git a/yast2-tune.spec.in b/yast2-tune.spec.in
-index d6f2256..4f6b49b 100644
+index d6f2256..a808c2d 100644
 --- a/yast2-tune.spec.in
 +++ b/yast2-tune.spec.in
-@@ -37,10 +37,9 @@ fi
+@@ -14,6 +14,8 @@ Obsoletes:	yast2-config-hwinfo yast2-tune-idedma yast2-trans-tune
+ Provides:	yast2-trans-hwinfo yast2-trans-idedma y2c_tune y2t_tune yast2-config-tune
+ Obsoletes:	yast2-trans-hwinfo yast2-trans-idedma y2c_tune y2t_tune yast2-config-tune
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Hardware Tuning
+ 
+ %description
+@@ -37,10 +39,9 @@ fi
  %defattr(-,root,root)
  
  @yncludedir@/hwinfo/*

--- a/patches/tv.patch
+++ b/patches/tv.patch
@@ -32,10 +32,19 @@ index 2a6f678..4cb582c 100644
 +
 +# include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-tv.spec.in b/yast2-tv.spec.in
-index 0656c33..99d7fd9 100644
+index 0656c33..c34b687 100644
 --- a/yast2-tv.spec.in
 +++ b/yast2-tv.spec.in
-@@ -49,9 +49,10 @@ fi
+@@ -20,6 +20,8 @@ PreReq:		sed
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - TV Configuration
+ 
+ %description
+@@ -49,9 +51,10 @@ fi
  %defattr(-,root,root)
  %dir @yncludedir@/tv
  @yncludedir@/tv/*

--- a/patches/update.patch
+++ b/patches/update.patch
@@ -34,10 +34,28 @@ index 9a2350a..b464f78 100644
 +#AUTODOCS_YCP=$(top_srcdir)/src/*/*.ycp
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-update.spec.in b/yast2-update.spec.in
-index 07df4cc..b8884b0 100644
+index 07df4cc..9283ea3 100644
 --- a/yast2-update.spec.in
 +++ b/yast2-update.spec.in
-@@ -71,19 +71,19 @@ Use this component if you wish to update your system.
+@@ -39,6 +39,8 @@ Conflicts:	yast2-pkg-bindings < 2.15.11
+ # Storage::DeviceMatchFstab (#244117)
+ Conflicts:	yast2-storage < 2.15.4
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Update
+ 
+ %package FACTORY
+@@ -50,6 +52,8 @@ Requires:	yast2-update yast2
+ # to remove dependency on yast2-storage
+ Provides:	yast2-update:/usr/share/YaST2/clients/update.ycp
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - Update
+ 
+ %description
+@@ -71,19 +75,19 @@ Use this component if you wish to update your system.
  @ybindir@/*
  @moduledir@/*
  
@@ -68,7 +86,7 @@ index 07df4cc..b8884b0 100644
  
  %doc @docdir@
  
-@@ -92,5 +92,5 @@ Use this component if you wish to update your system.
+@@ -92,5 +96,5 @@ Use this component if you wish to update your system.
  @desktopdir@/update.desktop
  %dir /usr/share/YaST2/control
  /usr/share/YaST2/control/update.xml

--- a/patches/users.patch
+++ b/patches/users.patch
@@ -52,10 +52,19 @@ index b6bc8cc..1412807 100644
  htmldir = @docdir@
  
 diff --git a/yast2-users.spec.in b/yast2-users.spec.in
-index dda3d5f..d6676a8 100644
+index dda3d5f..b946d47 100644
 --- a/yast2-users.spec.in
 +++ b/yast2-users.spec.in
-@@ -38,10 +38,10 @@ This package provides GUI for maintenance of linux users and groups.
+@@ -21,6 +21,8 @@ Requires:       yast2 >= 2.23.7
+ # cryptsha256, cryptsha516
+ Requires:       yast2-core >= 2.21.0
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	YaST2 - User and Group Configuration
+ 
+ %description
+@@ -38,10 +40,10 @@ This package provides GUI for maintenance of linux users and groups.
  %defattr(-,root,root)
  %dir @yncludedir@/users
  %dir @moduledir@/YaPI

--- a/patches/vm.patch
+++ b/patches/vm.patch
@@ -25,10 +25,19 @@ index 1ec3fcb..6bae5a9 100644
  htmldir = $(docdir)
  
 diff --git a/yast2-vm.spec.in b/yast2-vm.spec.in
-index 9ee2661..32ef464 100644
+index 9ee2661..4d7511a 100644
 --- a/yast2-vm.spec.in
 +++ b/yast2-vm.spec.in
-@@ -28,10 +28,10 @@ rm -f $RPM_BUILD_ROOT/usr/share/applications/YaST2/relocation-server.desktop
+@@ -7,6 +7,8 @@ BuildRequires:	perl-XML-Writer update-desktop-files yast2 yast2-devtools yast2-t
+ License:        GPL-2.0
+ Requires:	yast2 >= 2.21.22
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:	Configure Hypervisor and Tools for Xen and KVM
+ 
+ %description
+@@ -28,10 +30,10 @@ rm -f $RPM_BUILD_ROOT/usr/share/applications/YaST2/relocation-server.desktop
  %defattr(-,root,root)
  %dir @scrconfdir@
  %dir @yncludedir@

--- a/patches/wagon.patch
+++ b/patches/wagon.patch
@@ -43,10 +43,19 @@ index 0400e31..7716974 100644
 +#AUTODOCS_YCP=$(top_srcdir)/src/*/*.ycp
 +#include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/yast2-wagon.spec.in b/yast2-wagon.spec.in
-index 12d22e6..a6b9517 100644
+index 12d22e6..7c33d6f 100644
 --- a/yast2-wagon.spec.in
 +++ b/yast2-wagon.spec.in
-@@ -62,11 +62,10 @@ rm -rf %{buildroot}%%{_datadir}/YaST2/control/online_migration.xml
+@@ -39,6 +39,8 @@ Requires:	wagon-control-file
+ 
+ BuildArchitectures:	noarch
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary: YaST2 - Migration Tool for Service Packs
+ 
+ %description
+@@ -62,11 +64,10 @@ rm -rf %{buildroot}%%{_datadir}/YaST2/control/online_migration.xml
  %files
  %defattr(-,root,root)
  %{_prefix}/sbin/wagon

--- a/patches/yast2.patch
+++ b/patches/yast2.patch
@@ -965,7 +965,7 @@ index d4ecbd3..e69de29 100644
 -
 -include $(top_srcdir)/Makefile.am.common
 diff --git a/yast2.spec.in b/yast2.spec.in
-index 68b9f1a..2332317 100644
+index 68b9f1a..c8e7ff9 100644
 --- a/yast2.spec.in
 +++ b/yast2.spec.in
 @@ -78,6 +78,7 @@ Provides:       yast2-trans-menu y2t_menu
@@ -976,7 +976,16 @@ index 68b9f1a..2332317 100644
  Provides:       yast2-installation:/usr/share/YaST2/modules/Installation.ycp
  Provides:       yast2-installation:/usr/share/YaST2/modules/Product.ycp
  Provides:       yast2-installation:/usr/share/YaST2/modules/Hotplug.ycp
-@@ -180,15 +181,15 @@ mkdir -p "$RPM_BUILD_ROOT"/etc/YaST2
+@@ -87,6 +88,8 @@ Provides:       yast2-packager:/usr/lib/YaST2/servers_non_y2/ag_anyxml
+ Provides:       yast2-dns-server:/usr/share/YaST2/modules/DnsServerAPI.pm
+ Provides:       yast2-mail-aliases
+ 
++Requires:       yast2-ruby-bindings >= 1.0.0
++
+ Summary:        YaST2 - Main Package
+ 
+ %description
+@@ -180,15 +183,15 @@ mkdir -p "$RPM_BUILD_ROOT"/etc/YaST2
  
  # wizard
  %dir @yncludedir@/wizard
@@ -995,7 +1004,7 @@ index 68b9f1a..2332317 100644
  @desktopdir@/messages.desktop
  
  # documentation
-@@ -198,19 +199,19 @@ mkdir -p "$RPM_BUILD_ROOT"/etc/YaST2
+@@ -198,19 +201,19 @@ mkdir -p "$RPM_BUILD_ROOT"/etc/YaST2
  
  %doc @docdir@/autodocs
  %doc @docdir@/commandline


### PR DESCRIPTION
The modules need yast2-ruby-bindings package after switching to ruby.

(BuildRequires can be added later, now we do not run tests during build and then every ruby-bindings change would trigger complete yast rebuild.)
