### PR TITLE
Tv - keep the data files in YCP format for now

### DIFF
--- a/data/tv.yml
+++ b/data/tv.yml
@@ -19,3 +19,8 @@ moves:
   - from: "src/*.desktop"
     to: src/desktop
 
+excluded:
+  - src/data/tv_cards-lirc_gpio.ycp
+  - src/data/tv_dvbcards.ycp
+  - src/data/tv_dvbfirmware.ycp
+


### PR DESCRIPTION
to avoid "Unable to read the TV card database" error
in the 2nd installation stage
