### PR TITLE
Allow compiling of non-standalone include files using wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,17 @@ another file (called a *wrapper*). These include files and their wrappers need
 to be specified in the `include_wrappers` section in [module
 metadata](#module-metadata).
 
+You can recognize a non-standalone include file by compilation errors similar to
+this one:
+
+    /tmp/y2r20130530-20306-14322nv:770  [Parser] Undeclared identifier 'ChangeExistingSymbolsState'
+
+When the identifier is not declared in the include file itself, it means it is
+provided by some file the include file is included in. Little grepping around
+the module source usually reveals such a file, which can be then used as a
+wrapper. Note that sometimes includes are recursive, so you need to find a root
+of the whole chain.
+
 Compilation of each file can pass or fail with one of the following error:
 
   * **ERROR(y2r)** – the compilation failed when running `y2r`

--- a/README.md
+++ b/README.md
@@ -356,6 +356,11 @@ and *.yh files in the result directory are then replaced with converted *.rb
 files. All files specified in the `excluded` section in [module
 metadata](#module-metadata) are excluded from compilation and kept intact.
 
+Some include files are not standalone and need to be compiled in context of
+another file (called a *wrapper*). These include files and their wrappers need
+to be specified in the `include_wrappers` section in [module
+metadata](#module-metadata).
+
 Compilation of each file can pass or fail with one of the following error:
 
   * **ERROR(y2r)** – the compilation failed when running `y2r`
@@ -457,6 +462,17 @@ excluded:
   - library/sequencer/doc/examples/example2.ycp
   # This include file is not self-contained and can't be converted now.
   - library/packages/src/include/packages/common.ycp
+
+# A hash that maps include files that are not standalone into files in whose
+# context they should be compiled in ("wrappers").
+#
+# All paths here are in the new structure.
+#
+# Default: {}
+include_wrappers:
+  src/include/network/isdn/config.ycp: src/modules/ISDN.ycp
+  src/include/network/lan/wireless.ycp: src/clients/lan.ycp
+  src/include/network/lan/bridge: src/clients/lan.ycp
 
 # A list of module's exported directories. These are added to include path and
 # module path of YaST modules that depend on this module when compiling them

--- a/data/storage.yml
+++ b/data/storage.yml
@@ -41,7 +41,6 @@ excluded:
   - bindings/ycp/callback.ycp
   - bindings/ycp/example.ycp
   # TODO incomplete include files
-  - src/include/partitioning/custom_part_lib.ycp
   - src/include/partitioning/ep-lvm.ycp
   - src/include/partitioning/ep-lvm-lib.ycp
   - src/include/partitioning/ep-all.ycp

--- a/lib/yast_module.rb
+++ b/lib/yast_module.rb
@@ -15,18 +15,20 @@ class YastModule
     :obs_base_dir,
     :exports,
     :excluded,
-    :moves
+    :moves,
+    :include_wrappers
 
   def initialize(name, data, data_dir)
-    @name           = name
-    @work_dir       = "#{data_dir}/#{WORK_DIR}/#@name"
-    @result_dir     = "#{data_dir}/#{RESULT_DIR}/#@name"
-    @obs_base_dir   = "#{data_dir}/#{OBS_DIR}"
-    @ybc_dep_names  = data.delete("ybc_deps") || []
-    @ruby_dep_names = data.delete("ruby_deps") || []
-    @exports        = data.delete("exports") || ["src"]
-    @excluded       = data.delete("excluded") || []
-    @moves          = data.delete("moves") || []
+    @name             = name
+    @work_dir         = "#{data_dir}/#{WORK_DIR}/#@name"
+    @result_dir       = "#{data_dir}/#{RESULT_DIR}/#@name"
+    @obs_base_dir     = "#{data_dir}/#{OBS_DIR}"
+    @ybc_dep_names    = data.delete("ybc_deps") || []
+    @ruby_dep_names   = data.delete("ruby_deps") || []
+    @exports          = data.delete("exports") || ["src"]
+    @excluded         = data.delete("excluded") || []
+    @moves            = data.delete("moves") || []
+    @include_wrappers = data.delete("include_wrappers") || {}
 
     if !data.empty?
       Messages.warning "Unknown keys in #{name}.yml: #{data.keys.join(", ")}."


### PR DESCRIPTION
Some include files are not standalone and need to be compiled in context
of another file (called a _wrapper_). This commit allows specifying
these include files and their wrappers in the "include_wrappers" section
in module metadata. YCP Killer then uses this information to execute Y2R
on the wrapper with a special flag (--extract-file), which makes it to
generate Ruby code only for statements from the include file.
