### PR TITLE
yast2 - WorkflowManager.ycp handle *.rb files in addition to *.ycp

### DIFF
--- a/patches/yast2.patch
+++ b/patches/yast2.patch
@@ -476,6 +476,30 @@ index e692626..f2309b8 100644
 +
 +# AUTODOCS_SUBDIR=control
 +# include $(top_srcdir)/autodocs-ycp.ami
+diff --git a/library/control/src/modules/WorkflowManager.ycp b/library/control/src/modules/WorkflowManager.ycp
+index bc108bd..2fd3356 100644
+--- a/library/control/src/modules/WorkflowManager.ycp
++++ b/library/control/src/modules/WorkflowManager.ycp
+@@ -528,6 +528,8 @@ test -d '%1' || /bin/mkdir -p '%1';
+ 
+     /**
+      * Removes all xml and ycp files from directory where 
++     *
++     * TODO FIXME: this function seems to be unused, remove it?
+      */
+     global void CleanWorkflowsDirectory () {
+ 	string directory = GetWorkflowDirectory ();
+@@ -537,8 +539,8 @@ test -d '%1' || /bin/mkdir -p '%1';
+ 	    // doesn't add RPM dependency on tar
+ 	    map cmd = (map) SCR::Execute (.target.bash_ouptut, "
+ cd '%1';
+-test -x /bin/tar && /bin/tar -zcf workflows_backup.tgz *.xml *.ycp;
+-rm -rf *.xml *.ycp",
++test -x /bin/tar && /bin/tar -zcf workflows_backup.tgz *.xml *.ycp *.rb;
++rm -rf *.xml *.ycp *.rb",
+ 	    String::Quote (directory));
+ 
+ 	    if (cmd["exit"]:-1 != 0) {
 diff --git a/library/cron/doc/autodocs/Makefile.am b/library/cron/doc/autodocs/Makefile.am
 index d4a6854..b8295a9 100644
 --- a/library/cron/doc/autodocs/Makefile.am


### PR DESCRIPTION
added FIXME note as the function seems to be unused (remove it?)
