### PR TITLE
[Review] Request from '' @ 'yast/ycp-killer/export-private'

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,11 @@ the module source usually reveals such a file, which can be then used as a
 wrapper. Note that sometimes includes are recursive, so you need to find a root
 of the whole chain.
 
+Some modules may need to be converted with their private symbols exported. These
+modules need to be specified in the `export_private` section in [module
+metadata](#module-metadata). Exporting private symbols is usually needed because
+the testsuite uses them.
+
 Compilation of each file can pass or fail with one of the following error:
 
   * **ERROR(y2r)** – the compilation failed when running `y2r`
@@ -484,6 +489,14 @@ include_wrappers:
   src/include/network/isdn/config.ycp: src/modules/ISDN.ycp
   src/include/network/lan/wireless.ycp: src/clients/lan.ycp
   src/include/network/lan/bridge: src/clients/lan.ycp
+
+# A list of modules that should be compiled with their private symbols exported.
+#
+# All paths here are in the new structure.
+#
+# Default: []
+export_private:
+  - library/sequencer/src/modules/Sequencer.ycp
 
 # A list of module's exported directories. These are added to include path and
 # module path of YaST modules that depend on this module when compiling them

--- a/data/yast2.yml
+++ b/data/yast2.yml
@@ -100,6 +100,9 @@ moves:
     to: library/general/src/clients
   # TODO FIXME "remote/*.desktop" are ignored, remove from upstream
 
+export_private:
+  - library/sequencer/src/modules/Sequencer.ycp
+
 excluded:
   # include stuff for testsuite
   - library/sequencer/testsuite/tests/Wizard.yh
@@ -118,4 +121,3 @@ excluded:
   # do not convert (would fail at runtime)
   - library/general/src/data/country.ycp
   - library/general/src/data/country_long.ycp
-

--- a/lib/commands/ruby_command.rb
+++ b/lib/commands/ruby_command.rb
@@ -43,6 +43,8 @@ module Commands
               end
             end
 
+            options[:export_private] = mod.export_private.include?(file)
+
             file_action "Converting", :y2r, mod, file do
               create_rb mod, work_file, result_file, options
             end
@@ -85,6 +87,7 @@ module Commands
 
       cmd << "--as-include-file" if options[:is_include]
       cmd << "--extract-file" << extracted_file if options[:extracted_file]
+      cmd << "--export-private" if options[:export_private]
 
       cmd << file
       cmd << output_file

--- a/lib/yast_module.rb
+++ b/lib/yast_module.rb
@@ -16,7 +16,8 @@ class YastModule
     :exports,
     :excluded,
     :moves,
-    :include_wrappers
+    :include_wrappers,
+    :export_private
 
   def initialize(name, data, data_dir)
     @name             = name
@@ -29,6 +30,7 @@ class YastModule
     @excluded         = data.delete("excluded") || []
     @moves            = data.delete("moves") || []
     @include_wrappers = data.delete("include_wrappers") || {}
+    @export_private   = data.delete("export_private") || []
 
     if !data.empty?
       Messages.warning "Unknown keys in #{name}.yml: #{data.keys.join(", ")}."


### PR DESCRIPTION
Please review the following changes:
- 66aadcd Convert Sequencer.ycp with exported private symbols
- f814608 Allow to convert modules with private symbols exported
- 86c90e7 Refactor RubyCommand#create_rb API
