### PR TITLE
Revert a change done in storage.yml by mistake

### DIFF
--- a/data/storage.yml
+++ b/data/storage.yml
@@ -41,6 +41,7 @@ excluded:
   - bindings/ycp/callback.ycp
   - bindings/ycp/example.ycp
   # TODO incomplete include files
+  - src/include/partitioning/custom_part_lib.ycp
   - src/include/partitioning/ep-lvm.ycp
   - src/include/partitioning/ep-lvm-lib.ycp
   - src/include/partitioning/ep-all.ycp


### PR DESCRIPTION
An excluded file was removed in storage.yml by mistake in
a2d94e8e21737a7afdda4139a204f0be224788cf.
