### PR TITLE
yast2: publish more private symbols for the testsuite

### DIFF
--- a/data/yast2.yml
+++ b/data/yast2.yml
@@ -102,6 +102,8 @@ moves:
 
 export_private:
   - library/sequencer/src/modules/Sequencer.ycp
+  - library/network/src/modules/NetworkInterfaces.ycp
+  - library/commandline/src/modules/CommandLine.ycp
 
 excluded:
   # include stuff for testsuite


### PR DESCRIPTION
It fixes some test failures, but also introduces a different one, "Log    Builtin index called on nil" in the affected modules.
(can't look into it now, I have to go home)
