### PR TITLE
samba-server.yml: Improve include_wrappers a tiny bit

### DIFF
--- a/data/samba-server.yml
+++ b/data/samba-server.yml
@@ -27,4 +27,4 @@ moves:
     to:   src/autoyast-rnc
 
 include_wrappers:
-  src/include/samba-server/samba-options-local.ycp: src/clients/samba-server.ycp
+  src/include/samba-server/samba-options-local.ycp: src/include/samba-server/dialogs-items.ycp


### PR DESCRIPTION
Make samba-options-local.ycp compile in the context of "nearest"
self-contained include, not in a "toplevel" client. This will make the
compilation a tiny bit faster.
