### PR TITLE
updated patches/installation.patch

### DIFF
--- a/patches/installation.patch
+++ b/patches/installation.patch
@@ -105,22 +105,6 @@ index 3ef84e6..80773e2 100644
  	xmlns:xi="http://www.w3.org/2001/XInclude"/>
  
      </programlisting>
-diff --git a/src/clients/driver_update2_finish.ycp b/src/clients/driver_update2_finish.ycp
-index 909e81c..f9d3ae3 100644
---- a/src/clients/driver_update2_finish.ycp
-+++ b/src/clients/driver_update2_finish.ycp
-@@ -64,7 +64,10 @@ if (func == "Info")
- else if (func == "Write")
- {
-     Vendor::DriverUpdate2 ();
--    if (WFM::Read (.local.size, "/usr/share/YaST2/clients/product_finish.ycp") > 0)
-+    // product_finish client is provided by the driver update,
-+    // support both YCP and Ruby clients
-+    if (WFM::Read (.local.size, "/usr/share/YaST2/clients/product_finish.ycp") > 0
-+      || WFM::Read (.local.size, "/usr/share/YaST2/clients/product_finish.rb") > 0)
- 	WFM::CallFunction ("product_finish", [Mode::update ()]);
- }
- else
 diff --git a/src/clients/inst_automatic_configuration.ycp b/src/clients/inst_automatic_configuration.ycp
 index 0689035..66b2263 100644
 --- a/src/clients/inst_automatic_configuration.ycp


### PR DESCRIPTION
upstream now uses WFM::ClientExists() which supports also non-YCP clients,
no need for patching it here

(See https://github.com/yast/yast-installation/pull/46)
