### PR TITLE
hardware-detection -  keep the tests in YCP format

### DIFF
--- a/data/hardware-detection.yml
+++ b/data/hardware-detection.yml
@@ -5,3 +5,9 @@ moves:
   - from: conf/*.scr
     to: src/scrconf
 
+excluded:
+  # keep the tests in YCP format, the runag_hwprobe.cc wrapper uses
+  # scr/run_agent.h which explicitly uses YCP parser for running the tests
+  # (see https://github.com/yast/yast-core/blob/master/libscr/src/include/scr/run_agent.h#L130)
+  - testsuite/tests/arch.ycp
+  - testsuite/tests/dir.ycp

--- a/patches/hardware-detection.patch
+++ b/patches/hardware-detection.patch
@@ -32,34 +32,6 @@ index a710e62..20ad188 100644
 -	../src/libpy2ag_hwprobe.la		\
 +	../agent/libpy2ag_hwprobe.la		\
  	-Xlinker --no-whole-archive
-diff --git a/testsuite/ag_hwprobe.test/ag_hwprobe.exp b/testsuite/ag_hwprobe.test/ag_hwprobe.exp
-index 437379e..41e04cb 100644
---- a/testsuite/ag_hwprobe.test/ag_hwprobe.exp
-+++ b/testsuite/ag_hwprobe.test/ag_hwprobe.exp
-@@ -5,7 +5,7 @@
- 
- # get all files matching tests/*.ycp
- 
--set filenames [glob $srcdir/tests/*.ycp]
-+set filenames [glob $srcdir/tests/*.rb]
- 
- # foreach file, call ycp-run (from testsuite/lib)
- 
-diff --git a/testsuite/lib/ag_hwprobe_init.exp b/testsuite/lib/ag_hwprobe_init.exp
-index 871b6b5..e55d9eb 100644
---- a/testsuite/lib/ag_hwprobe_init.exp
-+++ b/testsuite/lib/ag_hwprobe_init.exp
-@@ -14,8 +14,8 @@ proc ycp-run { src } {
-     fail "Bad filename syntax '$src'"
-     return -1
-   }
--  if {[lindex $fname [expr [llength $fname]-1]] != "ycp"} {
--    fail "Not .ycp extension '$src'"
-+  if {[lindex $fname [expr [llength $fname]-1]] != "rb"} {
-+    fail "Not .rb extension '$src'"
-     return -1
-   }
- 
 diff --git a/testsuite/runag_hwprobe.cc b/testsuite/runag_hwprobe.cc
 index 08f8d0d..59d2218 100644
 --- a/testsuite/runag_hwprobe.cc
@@ -73,17 +45,6 @@ index 08f8d0d..59d2218 100644
  
  
  int
-diff --git a/testsuite/tests/Makefile.am b/testsuite/tests/Makefile.am
-index 78aebd5..f8da694 100644
---- a/testsuite/tests/Makefile.am
-+++ b/testsuite/tests/Makefile.am
-@@ -2,5 +2,5 @@
- # Makefile.am for core/agent-probe/testsuite/tests
- #
- 
--EXTRA_DIST = *.ycp *.out *.err runtest.sh
-+EXTRA_DIST = *.rb *.out *.err runtest.sh
- 
 diff --git a/yast2-hardware-detection.spec.in b/yast2-hardware-detection.spec.in
 index 3f57467..13fb51e 100644
 --- a/yast2-hardware-detection.spec.in


### PR DESCRIPTION
the `runag_hwprobe.cc` wrapper uses `scr/run_agent.h` which explicitly
uses YCP parser for running the tests so only YCP tests are supported

(see https://github.com/yast/yast-core/blob/master/libscr/src/include/scr/run_agent.h#L130)
