### PR TITLE
Translate include files in testsuite correctly

### DIFF
--- a/lib/commands/ruby_command.rb
+++ b/lib/commands/ruby_command.rb
@@ -29,15 +29,26 @@ module Commands
             FileUtils.rm "#{mod.result_dir}/#{file}"
             result_file = "#{mod.result_dir}/#{file}".sub(/\.y(cp|h)$/, ".rb")
 
-            options = {
-              :is_include => mod.exports.any? do |export|
-                file.start_with?("#{export}/include")
-              end
-            }
+            options = {}
+
+            is_in_include_dir = mod.exports.any? do |export|
+              file.start_with?("#{export}/include")
+            end
+            is_yh = file.end_with?(".yh")
+
+            options[:is_include] = is_in_include_dir || is_yh
 
             if options[:is_include]
               options[:extracted_file] = if mod.include_wrappers[file]
-                file.sub(/^.*\/include\//, "")
+                # We assume that if an include file isn't in the include dir,
+                # the wrapper file includes it just using its base name. This
+                # seems to be true for all such include files we have.
+
+                if is_in_include_dir
+                  file.sub(/^.*\/include\//, "")
+                else
+                  File.basename(file)
+                end
               else
                 nil
               end


### PR DESCRIPTION
Include files in the testsuite (which always have the .yh extension)
aren't in any exported directory, so they weren't considered as include
files by our code until now.

This commit extends the logic so that it always considers *.yh files as
include files, wherever they are. It also makes sure that sane
--extract-file option value is passed to Y2R for them.
