### PR TITLE
Update yast2 patch to make the testsuite pass

### DIFF
--- a/patches/yast2.patch
+++ b/patches/yast2.patch
@@ -1,6 +1,3 @@
-TODO FIXME: remove patch for updating testedfiles in cwm/testsuite files
-(it's just a temporary workaround for inlined include files)
-
 TODO FIXME: remove the patch for PortAliases.ycp after fixing
 https://github.com/yast/y2r/issues/20
 
@@ -234,6 +231,22 @@ index e69a0f4..8ba5163 100644
 +	foreach(term row, content, { PrintLine(row, widths, aligns); });
      }
  
+ 
+diff --git a/library/commandline/testsuite/Makefile.am b/library/commandline/testsuite/Makefile.am
+index d9b12b0..956c637 100644
+--- a/library/commandline/testsuite/Makefile.am
++++ b/library/commandline/testsuite/Makefile.am
+@@ -5,7 +5,10 @@
+ #
+ 
+ AUTOMAKE_OPTIONS = dejagnu
+-EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.ycp) $(wildcard tests/*.yh)
++EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.rb)
++
++Y2BASEFLAGS = -I tests
++export Y2BASEFLAGS
+ 
+ testsuite_prepare = @ydatadir@/testsuite/Makefile.testsuite
  
 diff --git a/library/commandline/testsuite/tests/cmdmap6.ycp b/library/commandline/testsuite/tests/cmdmap6.ycp
 index 184a4ed..190f383 100644
@@ -496,6 +509,26 @@ index e692626..f2309b8 100644
 +
 +# AUTODOCS_SUBDIR=control
 +# include $(top_srcdir)/autodocs-ycp.ami
+diff --git a/library/control/src/modules/ProductControl.ycp b/library/control/src/modules/ProductControl.ycp
+index 90bc26e..e4d65d9 100644
+--- a/library/control/src/modules/ProductControl.ycp
++++ b/library/control/src/modules/ProductControl.ycp
+@@ -565,6 +565,7 @@ void PrepareScripts(map m)
+ /**
+  * Get list of required files for the workflow.
+  * @return list<string> Required files list.
++ * TODO FIXME: this function seems to be unused, remove it?
+  */
+ global list<string> RequiredFiles (string stage, string mode) 
+ {
+@@ -595,6 +596,7 @@ global list<string> RequiredFiles (string stage, string mode)
+ 		client = "inst_" + m["name"]:"dummy";
+ 	    }
+ 	}
++        // TODO FIXME: what about the ruby files?
+ 	client = Directory::clientdir + "/" + client + ".ycp";
+ 	needed_client_files = add(needed_client_files, client);
+     });
 diff --git a/library/control/src/modules/WorkflowManager.ycp b/library/control/src/modules/WorkflowManager.ycp
 index bc108bd..2fd3356 100644
 --- a/library/control/src/modules/WorkflowManager.ycp
@@ -520,6 +553,19 @@ index bc108bd..2fd3356 100644
  	    String::Quote (directory));
  
  	    if (cmd["exit"]:-1 != 0) {
+diff --git a/library/control/testsuite/Makefile.am b/library/control/testsuite/Makefile.am
+index d9b12b0..e85fbc8 100644
+--- a/library/control/testsuite/Makefile.am
++++ b/library/control/testsuite/Makefile.am
+@@ -5,7 +5,7 @@
+ #
+ 
+ AUTOMAKE_OPTIONS = dejagnu
+-EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.ycp) $(wildcard tests/*.yh)
++EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.rb)
+ 
+ testsuite_prepare = @ydatadir@/testsuite/Makefile.testsuite
+ 
 diff --git a/library/cron/doc/autodocs/Makefile.am b/library/cron/doc/autodocs/Makefile.am
 index d4a6854..b8295a9 100644
 --- a/library/cron/doc/autodocs/Makefile.am
@@ -546,6 +592,22 @@ index 2b51cd4..dde9eef 100644
 +
 +#AUTODOCS_SUBDIR=cwm
 +#include $(top_srcdir)/autodocs-ycp.ami
+diff --git a/library/cwm/testsuite/Makefile.am b/library/cwm/testsuite/Makefile.am
+index d9b12b0..956c637 100644
+--- a/library/cwm/testsuite/Makefile.am
++++ b/library/cwm/testsuite/Makefile.am
+@@ -5,7 +5,10 @@
+ #
+ 
+ AUTOMAKE_OPTIONS = dejagnu
+-EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.ycp) $(wildcard tests/*.yh)
++EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.rb)
++
++Y2BASEFLAGS = -I tests
++export Y2BASEFLAGS
+ 
+ testsuite_prepare = @ydatadir@/testsuite/Makefile.testsuite
+ 
 diff --git a/library/cwm/testsuite/tests/t1.out b/library/cwm/testsuite/tests/t1.out
 index a253f1f..3e77037 100644
 --- a/library/cwm/testsuite/tests/t1.out
@@ -568,18 +630,9 @@ index a253f1f..3e77037 100644
  Dump	Init
  Log	w1_init: Initing w1
 diff --git a/library/cwm/testsuite/tests/t1.ycp b/library/cwm/testsuite/tests/t1.ycp
-index afa62bb..186dd59 100644
+index afa62bb..13ddb6b 100644
 --- a/library/cwm/testsuite/tests/t1.ycp
 +++ b/library/cwm/testsuite/tests/t1.ycp
-@@ -34,7 +34,7 @@ you may find current contact information at www.novell.com
-  *
-  * $Id$
-  *
-- * testedfiles: CWM.ycp testfunc.yh Testsuite.ycp
-+ * testedfiles: CWM.ycp testfunc.yh Testsuite.ycp tests/t1.rb
-  */
- 
- {
 @@ -43,10 +43,9 @@ you may find current contact information at www.novell.com
      import "Report";
  
@@ -622,18 +675,9 @@ index 4a07e63..d70121d 100644
  Dump	Run popup
  Log	fallback_init: id nil, key a
 diff --git a/library/cwm/testsuite/tests/t2.ycp b/library/cwm/testsuite/tests/t2.ycp
-index a86971d..4e48d2c 100644
+index a86971d..8e45382 100644
 --- a/library/cwm/testsuite/tests/t2.ycp
 +++ b/library/cwm/testsuite/tests/t2.ycp
-@@ -34,7 +34,7 @@ you may find current contact information at www.novell.com
-  *
-  * $Id$
-  *
-- * testedfiles: CWM.ycp testfunc.yh Testsuite.ycp
-+ * testedfiles: CWM.ycp testfunc.yh Testsuite.ycp tests/t2.rb
-  */
- 
- {
 @@ -48,10 +48,9 @@ you may find current contact information at www.novell.com
      import "Report";
  
@@ -715,6 +759,19 @@ index 1f9c470..19a4533 100644
 -
 -include $(top_srcdir)/Makefile.am.common
 +SUBDIRS = src testsuite
+diff --git a/library/general/testsuite/Makefile.am b/library/general/testsuite/Makefile.am
+index d9b12b0..e85fbc8 100644
+--- a/library/general/testsuite/Makefile.am
++++ b/library/general/testsuite/Makefile.am
+@@ -5,7 +5,7 @@
+ #
+ 
+ AUTOMAKE_OPTIONS = dejagnu
+-EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.ycp) $(wildcard tests/*.yh)
++EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.rb)
+ 
+ testsuite_prepare = @ydatadir@/testsuite/Makefile.testsuite
+ 
 diff --git a/library/gpg/doc/Makefile.am b/library/gpg/doc/Makefile.am
 index f855694..6a765c1 100644
 --- a/library/gpg/doc/Makefile.am
@@ -839,6 +896,19 @@ index d632271..f9e1520 100644
  
  	    // not a known port
  	    if (port_number == nil) {
+diff --git a/library/network/testsuite/Makefile.am b/library/network/testsuite/Makefile.am
+index d9b12b0..e85fbc8 100644
+--- a/library/network/testsuite/Makefile.am
++++ b/library/network/testsuite/Makefile.am
+@@ -5,7 +5,7 @@
+ #
+ 
+ AUTOMAKE_OPTIONS = dejagnu
+-EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.ycp) $(wildcard tests/*.yh)
++EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.rb)
+ 
+ testsuite_prepare = @ydatadir@/testsuite/Makefile.testsuite
+ 
 diff --git a/library/packages/doc/autodocs/Makefile.am b/library/packages/doc/autodocs/Makefile.am
 index 0f42745..0d975b6 100644
 --- a/library/packages/doc/autodocs/Makefile.am
@@ -923,6 +993,19 @@ index 9b035c1..af813bf 100644
   * Has Pkg::TargetInit run?
   */
  boolean target_initialized = false;
+diff --git a/library/packages/testsuite/Makefile.am b/library/packages/testsuite/Makefile.am
+index d9b12b0..e85fbc8 100644
+--- a/library/packages/testsuite/Makefile.am
++++ b/library/packages/testsuite/Makefile.am
+@@ -5,7 +5,7 @@
+ #
+ 
+ AUTOMAKE_OPTIONS = dejagnu
+-EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.ycp) $(wildcard tests/*.yh)
++EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.rb)
+ 
+ testsuite_prepare = @ydatadir@/testsuite/Makefile.testsuite
+ 
 diff --git a/library/runlevel/doc/autodocs/Makefile.am b/library/runlevel/doc/autodocs/Makefile.am
 index 806afad..926ff20 100644
 --- a/library/runlevel/doc/autodocs/Makefile.am
@@ -936,6 +1019,19 @@ index 806afad..926ff20 100644
 +
 +#AUTODOCS_SUBDIR=runlevel
 +#include $(top_srcdir)/autodocs-ycp.ami
+diff --git a/library/runlevel/testsuite/Makefile.am b/library/runlevel/testsuite/Makefile.am
+index d9b12b0..e85fbc8 100644
+--- a/library/runlevel/testsuite/Makefile.am
++++ b/library/runlevel/testsuite/Makefile.am
+@@ -5,7 +5,7 @@
+ #
+ 
+ AUTOMAKE_OPTIONS = dejagnu
+-EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.ycp) $(wildcard tests/*.yh)
++EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.rb)
+ 
+ testsuite_prepare = @ydatadir@/testsuite/Makefile.testsuite
+ 
 diff --git a/library/sequencer/doc/autodocs/Makefile.am b/library/sequencer/doc/autodocs/Makefile.am
 index 449d581..7281339 100644
 --- a/library/sequencer/doc/autodocs/Makefile.am
@@ -949,6 +1045,22 @@ index 449d581..7281339 100644
 +
 +#AUTODOCS_SUBDIR=sequencer
 +#include $(top_srcdir)/autodocs-ycp.ami
+diff --git a/library/sequencer/testsuite/Makefile.am b/library/sequencer/testsuite/Makefile.am
+index d9b12b0..956c637 100644
+--- a/library/sequencer/testsuite/Makefile.am
++++ b/library/sequencer/testsuite/Makefile.am
+@@ -5,7 +5,10 @@
+ #
+ 
+ AUTOMAKE_OPTIONS = dejagnu
+-EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.ycp) $(wildcard tests/*.yh)
++EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.rb)
++
++Y2BASEFLAGS = -I tests
++export Y2BASEFLAGS
+ 
+ testsuite_prepare = @ydatadir@/testsuite/Makefile.testsuite
+ 
 diff --git a/library/sequencer/testsuite/tests/WS_check.ycp b/library/sequencer/testsuite/tests/WS_check.ycp
 index 9e11a70..fe8dd72 100644
 --- a/library/sequencer/testsuite/tests/WS_check.ycp
@@ -1084,6 +1196,19 @@ index 6248ff4..ae166c7 100644
 +
 +#AUTODOCS_SUBDIR=system
 +#include $(top_srcdir)/autodocs-ycp.ami
+diff --git a/library/system/testsuite/Makefile.am b/library/system/testsuite/Makefile.am
+index d9b12b0..e85fbc8 100644
+--- a/library/system/testsuite/Makefile.am
++++ b/library/system/testsuite/Makefile.am
+@@ -5,7 +5,7 @@
+ #
+ 
+ AUTOMAKE_OPTIONS = dejagnu
+-EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.ycp) $(wildcard tests/*.yh)
++EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.rb)
+ 
+ testsuite_prepare = @ydatadir@/testsuite/Makefile.testsuite
+ 
 diff --git a/library/types/doc/autodocs/Makefile.am b/library/types/doc/autodocs/Makefile.am
 index 2c416a5..4e95b91 100644
 --- a/library/types/doc/autodocs/Makefile.am
@@ -1097,6 +1222,19 @@ index 2c416a5..4e95b91 100644
 +
 +#AUTODOCS_SUBDIR=types
 +#include $(top_srcdir)/autodocs-ycp.ami
+diff --git a/library/types/testsuite/Makefile.am b/library/types/testsuite/Makefile.am
+index d9b12b0..e85fbc8 100644
+--- a/library/types/testsuite/Makefile.am
++++ b/library/types/testsuite/Makefile.am
+@@ -5,7 +5,7 @@
+ #
+ 
+ AUTOMAKE_OPTIONS = dejagnu
+-EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.ycp) $(wildcard tests/*.yh)
++EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.rb)
+ 
+ testsuite_prepare = @ydatadir@/testsuite/Makefile.testsuite
+ 
 diff --git a/library/wizard/doc/autodocs/Makefile.am b/library/wizard/doc/autodocs/Makefile.am
 index 60abcb8..452a0bb 100644
 --- a/library/wizard/doc/autodocs/Makefile.am
@@ -1228,23 +1366,3 @@ index 68b9f1a..72ef8e3 100644
 -%doc @docdir@/xml
  
  %changelog
-diff --git a/library/control/src/modules/ProductControl.ycp b/library/control/src/modules/ProductControl.ycp
-index 90bc26e..e4d65d9 100644
---- a/library/control/src/modules/ProductControl.ycp
-+++ b/library/control/src/modules/ProductControl.ycp
-@@ -565,6 +565,7 @@ void PrepareScripts(map m)
- /**
-  * Get list of required files for the workflow.
-  * @return list<string> Required files list.
-+ * TODO FIXME: this function seems to be unused, remove it?
-  */
- global list<string> RequiredFiles (string stage, string mode) 
- {
-@@ -595,6 +596,7 @@ global list<string> RequiredFiles (string stage, string mode)
- 		client = "inst_" + m["name"]:"dummy";
- 	    }
- 	}
-+        // TODO FIXME: what about the ruby files?
- 	client = Directory::clientdir + "/" + client + ".ycp";
- 	needed_client_files = add(needed_client_files, client);
-     });


### PR DESCRIPTION
- removed workaround for testedfiles in cwm/testsuite
- properly pack the .rb tests
- add "-I tests" option to properly handle include files in tests
