### PR TITLE
testsuite.patch - add yast2-ruby-bindings to BuildRequires

### DIFF
--- a/patches/testsuite.patch
+++ b/patches/testsuite.patch
@@ -56,10 +56,14 @@ index 5596f82..f86f329 100644
  map READ = $[ "read" : $[ "path" : "read_result" ] ];
  map WRITE = $[ "write" : $[ "path" : true ] ];
 diff --git a/yast2-testsuite.spec.in b/yast2-testsuite.spec.in
-index 9c5c8b6..4e1adce 100644
+index 27aa3af..64dd90b 100644
 --- a/yast2-testsuite.spec.in
 +++ b/yast2-testsuite.spec.in
-@@ -7,6 +7,8 @@ BuildRequires:	openslp-devel perl-XML-Writer popt-devel yast2-core-devel yast2-d
+@@ -4,9 +4,12 @@
+ Group:	System/YaST
+ License: GPL-2.0+
+ BuildRequires:	yast2-core-devel yast2-devtools yast2-ycp-ui-bindings
++BuildRequires:  yast2-ruby-bindings >= 1.0.0
  Requires:	expect dejagnu
  # y2base -I includepath -M modulepath
  Requires:	yast2-core >= 2.19.0


### PR DESCRIPTION
needed to run the tests during RPM build
