### PR TITLE
Always call Y2R with the --report-file option

### DIFF
--- a/lib/commands/ruby_command.rb
+++ b/lib/commands/ruby_command.rb
@@ -48,10 +48,10 @@ module Commands
                 else
                   File.basename(file)
                 end
-
-                options[:reported_file] = file
               end
             end
+
+            options[:reported_file] = file
 
             options[:export_private] = mod.export_private.include?(file)
 


### PR DESCRIPTION
Before this commit, the --reported-file option was used only for wrapped
include files. For all other files, the option was not passed and Y2R
used the input filename as the one it reported. Because passed input
filename was absolute, Y2R emitted comments like this at the beginning
of generated code:

  # Translated by Y2R (https://github.com/yast/y2r).
  #
  # Original file: /home/dmajda/.local/share/ycp-killer/work/testsuite/src/modules/Testsuite.ycp

This commit makes YCP Killer always pass the --reported-file option,
passing a module-relative path there. This means that Y2R now emits
comments like this for all files:

  # Translated by Y2R (https://github.com/yast/y2r).
  #
  # Original file: src/modules/Testsuite.ycp

Much better :-)
