### PR TITLE
convert *.{ycp,yh}.in files

### DIFF
--- a/lib/commands/ruby_command.rb
+++ b/lib/commands/ruby_command.rb
@@ -21,20 +21,20 @@ module Commands
         ENV["Y2ALLGLOBAL"] = "1"
 
         Dir.chdir mod.work_dir do
-          Threading.in_parallel Dir["**/*.y{cp,h}"] do |file|
+          Threading.in_parallel Dir["**/*.y{cp,h}{.in,}"] do |file|
             next if mod.excluded.include?(file)
 
             converted_file = mod.include_wrappers[file] || file
             work_file = "#{mod.work_dir}/#{converted_file}"
             FileUtils.rm "#{mod.result_dir}/#{file}"
-            result_file = "#{mod.result_dir}/#{file}".sub(/\.y(cp|h)$/, ".rb")
+            result_file = "#{mod.result_dir}/#{file}".sub(/\.y(cp|h)$/, ".rb").sub(/\.y(cp|h)\.in$/, ".rb.in")
 
             options = {}
 
             is_in_include_dir = mod.exports.any? do |export|
               file.start_with?("#{export}/include")
             end
-            is_yh = file.end_with?(".yh")
+            is_yh = file.end_with?(".yh") || file.end_with?(".yh.in")
 
             options[:is_include] = is_in_include_dir || is_yh
 

--- a/patches/yast2.patch
+++ b/patches/yast2.patch
@@ -1,5 +1,5 @@
 diff --git a/configure.in.in b/configure.in.in
-index eaa7454..4cbb1d1 100644
+index eaa7454..b8f73d2 100644
 --- a/configure.in.in
 +++ b/configure.in.in
 @@ -32,6 +32,6 @@ AC_MSG_RESULT([$IFCFG_DIR])
@@ -8,7 +8,7 @@ index eaa7454..4cbb1d1 100644
  # also done via makefile
 -AC_CONFIG_FILES(library/modules/Version.ycp
 -library/network/agents/network.scr)
-+AC_CONFIG_FILES(library/general/src/modules/Version.ycp
++AC_CONFIG_FILES(library/general/src/modules/Version.rb
 +library/network/src/scrconf/network.scr)
  @YAST2-OUTPUT@
 diff --git a/data/Makefile.am b/data/Makefile.am
@@ -93,7 +93,6 @@ index 3fd9da9..e20f556 100644
 +
 +#AUTODOCS_SUBDIR=commandline
 +#include $(top_srcdir)/autodocs-ycp.ami
-diff --git a/library/commandline/src/modules/CommandLine.ycp b/library/commandline/src/modules/CommandLine.ycp
 diff --git a/library/commandline/testsuite/Makefile.am b/library/commandline/testsuite/Makefile.am
 index d9b12b0..956c637 100644
 --- a/library/commandline/testsuite/Makefile.am
@@ -588,6 +587,24 @@ index 1f9c470..19a4533 100644
 -
 -include $(top_srcdir)/Makefile.am.common
 +SUBDIRS = src testsuite
+diff --git a/library/general/src/modules/Version.ycp.in b/library/general/src/modules/Version.ycp.in
+index 7111bec..c8b746e 100644
+--- a/library/general/src/modules/Version.ycp.in
++++ b/library/general/src/modules/Version.ycp.in
+@@ -6,11 +6,11 @@
+  *
+  * $Id$
+  *
+- * Version.ycp is a <b>
++ * Version.rb is a <b>
+  *
+  * ** GENERATED FILE **
+  *
+- * </b>, so edit Version.ycp.in instead.
++ * </b>, so edit Version.rb.in instead.
+  */
+ 
+ {
 diff --git a/library/general/testsuite/Makefile.am b/library/general/testsuite/Makefile.am
 index d9b12b0..e85fbc8 100644
 --- a/library/general/testsuite/Makefile.am
@@ -1015,10 +1032,10 @@ index d4ecbd3..e69de29 100644
 -
 -include $(top_srcdir)/Makefile.am.common
 diff --git a/yast2.spec.in b/yast2.spec.in
-index 68b9f1a..72ef8e3 100644
+index 68b9f1a..d4d9177 100644
 --- a/yast2.spec.in
 +++ b/yast2.spec.in
-@@ -87,6 +88,8 @@ Provides:       yast2-packager:/usr/lib/YaST2/servers_non_y2/ag_anyxml
+@@ -87,6 +87,8 @@ Provides:       yast2-packager:/usr/lib/YaST2/servers_non_y2/ag_anyxml
  Provides:       yast2-dns-server:/usr/share/YaST2/modules/DnsServerAPI.pm
  Provides:       yast2-mail-aliases
  
@@ -1027,7 +1044,7 @@ index 68b9f1a..72ef8e3 100644
  Summary:        YaST2 - Main Package
  
  %description
-@@ -180,15 +183,15 @@ mkdir -p "$RPM_BUILD_ROOT"/etc/YaST2
+@@ -180,15 +182,15 @@ mkdir -p "$RPM_BUILD_ROOT"/etc/YaST2
  
  # wizard
  %dir @yncludedir@/wizard
@@ -1046,7 +1063,7 @@ index 68b9f1a..72ef8e3 100644
  @desktopdir@/messages.desktop
  
  # documentation
-@@ -198,19 +201,19 @@ mkdir -p "$RPM_BUILD_ROOT"/etc/YaST2
+@@ -198,19 +200,19 @@ mkdir -p "$RPM_BUILD_ROOT"/etc/YaST2
  
  %doc @docdir@/autodocs
  %doc @docdir@/commandline


### PR DESCRIPTION
convert `Version.ycp.in` file to `Version.rb.in` which is used as a template
for autoconf
