### PR TITLE
Remove TODO at "make -f Makefile.cvs" invocation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ gem "cheetah",       "0.3.0"
 gem "smart_colored", "1.1.1"
 gem "thor",          "0.17.0"
 
-gem "y2r", :git => "git://github.com/yast/y2r.git"
+gem "y2r", :git => "git://github.com/yast/y2r.git", :branch => "parens-by-priority-2"

--- a/lib/commands/package_command.rb
+++ b/lib/commands/package_command.rb
@@ -11,7 +11,7 @@ module Commands
           # do not check for configured
           # rubygems in external ruby scripts called during packaging
           disable_bundler do
-            Cheetah.run "make", "-f", "Makefile.cvs" # TODO will not work for cmake based ones
+            Cheetah.run "make", "-f", "Makefile.cvs"
             Cheetah.run "make", "package-local", "CHECK_SYNTAX=false"
           end
         end


### PR DESCRIPTION
There is no CMake-based module among the translated ones, so we won't be
adding CMake support.
