### PR TITLE
yast2 - fix generating autodocs

### DIFF
--- a/patches/yast2.patch
+++ b/patches/yast2.patch
@@ -30,13 +30,16 @@ index 55e4a9d..e471c86 100644
 +EXTRA_DIST = $(xversion_DATA)
  include $(top_srcdir)/Makefile.am.common
 diff --git a/doc/autodocs/Makefile.am b/doc/autodocs/Makefile.am
-index 7dca6f8..2a6f678 100644
+index 7dca6f8..7f04d21 100644
 --- a/doc/autodocs/Makefile.am
 +++ b/doc/autodocs/Makefile.am
-@@ -1,4 +1,3 @@
+@@ -1,4 +1,6 @@
  # Makefile.am for YCP module .../doc/autodocs
  
 -AUTODOCS_YCP=$(srcdir)/../../library/*/*.ycp
++AUTODOCS_PM = $(wildcard $(srcdir)/../../library/general/src/modules/*.pm)
++AUTODOCS_RB = $(wildcard $(srcdir)/../../library/general/src/modules/*.rb)
++
  include $(top_srcdir)/autodocs-ycp.ami
 diff --git a/library/Makefile.am b/library/Makefile.am
 index 5083c46..c85c318 100644
@@ -835,7 +838,7 @@ index d4ecbd3..e69de29 100644
 -
 -include $(top_srcdir)/Makefile.am.common
 diff --git a/yast2.spec.in b/yast2.spec.in
-index 68b9f1a..d4d9177 100644
+index 68b9f1a..304c448 100644
 --- a/yast2.spec.in
 +++ b/yast2.spec.in
 @@ -87,6 +87,8 @@ Provides:       yast2-packager:/usr/lib/YaST2/servers_non_y2/ag_anyxml


### PR DESCRIPTION
the files are now in `general/` subdir
