### PR TITLE
data/wagon.yml - removed FIXME note

### DIFF
--- a/data/wagon.yml
+++ b/data/wagon.yml
@@ -10,7 +10,6 @@ moves:
     to:   src/include/wagon
   - from: "src/config/cd_update.desktop"
     to:   src/desktop
-  # TODO FIXME: add support for control files?
   - from: "src/config/online_migration-*.xml"
     to:   control
   - from: "src/config/Makefile.am"


### PR DESCRIPTION
the support for control files is not worth of adding it,
it is used just in 5 installation specific packages...
