### PR TITLE
data/installation.yml - removed TODO note

### DIFF
--- a/data/installation.yml
+++ b/data/installation.yml
@@ -17,7 +17,6 @@ moves:
   - from: "src/config/*.rnc"
     to: src/autoyast-rnc
 
-    # TODO: maybe support /usr/share/autoinstall/modules/*.desktop targets?
   - from: "src/config/{deploy_image.desktop,Makefile.am}"
     to: autoyast_desktop
 


### PR DESCRIPTION
autoinstall/modules/*.desktop targets are used just in 3 packages,
it's not worth of implementing that...
