### PR TITLE
add-on-creator.yml, product-creator.yml - removed FIXME

### DIFF
--- a/data/add-on-creator.yml
+++ b/data/add-on-creator.yml
@@ -10,7 +10,6 @@ moves:
     to:   src/include/add-on-creator
   - from: "src/add-on-creator.desktop"
     to:   src/desktop
-  # TODO FIXME: it is in a data/ subdirectory
   - from: "src/{template.prod,Makefile.am}"
     to:   data
   - from: "agents/ag_*"

--- a/data/product-creator.yml
+++ b/data/product-creator.yml
@@ -20,7 +20,6 @@ moves:
     to:   src/bin
   - from: "src/data/sysconfig.product-creator"
     to:   src/fillup
-  # TODO FIXME: data are in a subdir
   - from: "src/data"
     to: "."
 


### PR DESCRIPTION
data subdir support makes no sense just for four packages
(also used in country and testsuite)

keep it as it is now, just remove the FIXME
