### PR TITLE
storage - enable converting callback.ycp and example.ycp file

### DIFF
--- a/data/storage.yml
+++ b/data/storage.yml
@@ -79,10 +79,3 @@ excluded:
   # Keep the datafiles in YCP format
   - src/data/demo_target_map.ycp
   - src/data/test_target_map.ycp
-  # TODO: These are the only files using LibStorage::initDefaultLogger which is
-  #       an overloaded function. pluglib-bindings (the YCP addition over SWIG)
-  #       don't handle the overloading, letting YCP see only one variant at
-  #       random. If there are real uses of overloaded functions, this should
-  #       be fixed either upstream or in our stubs.
-  - bindings/ycp/callback.ycp
-  - bindings/ycp/example.ycp

--- a/patches/storage.patch
+++ b/patches/storage.patch
@@ -16,6 +16,16 @@ index a2c2946..0000000
 -	       sysconfig_storage.scr
 -
 -EXTRA_DIST = $(scrconf_DATA)
+diff --git a/bindings/ycp/Makefile.am b/bindings/ycp/Makefile.am
+index 7968bc0..a5f0232 100644
+--- a/bindings/ycp/Makefile.am
++++ b/bindings/ycp/Makefile.am
+@@ -11,4 +11,4 @@ PLUGLIB_DEPEND =					\
+ 
+ include $(top_srcdir)/pluglib-bindings.ami
+ 
+-EXTRA_DIST = LibStorage.i example.ycp
++EXTRA_DIST = LibStorage.i example.rb callback.rb
 diff --git a/data/Makefile.am b/data/Makefile.am
 deleted file mode 100644
 index 1e7e401..0000000


### PR DESCRIPTION
the LibStorage::initDefaultLogger() issue has been solved upstream
