### PR TITLE
Sync add-on patch with upstream

### DIFF
--- a/patches/add-on.patch
+++ b/patches/add-on.patch
@@ -1,16 +1,3 @@
-diff --git a/testsuite/Makefile.am b/testsuite/Makefile.am
-index d9b12b0..e85fbc8 100644
---- a/testsuite/Makefile.am
-+++ b/testsuite/Makefile.am
-@@ -5,7 +5,7 @@
- #
- 
- AUTOMAKE_OPTIONS = dejagnu
--EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.ycp) $(wildcard tests/*.yh)
-+EXTRA_DIST = $(wildcard tests/*.out) $(wildcard tests/*.err) $(wildcard tests/*.rb)
- 
- testsuite_prepare = @ydatadir@/testsuite/Makefile.testsuite
- 
 diff --git a/yast2-add-on.spec.in b/yast2-add-on.spec.in
 index ef8280b..2a88a5b 100644
 --- a/yast2-add-on.spec.in


### PR DESCRIPTION
The testsuite/Makefile.am file was removed in upstream, we need to
remove it from the patch too.
