### PR TITLE
Remove "break" statemetns that break Y2R

### DIFF
--- a/patches/network.patch
+++ b/patches/network.patch
@@ -30,6 +30,18 @@ index a708e92..2a6f678 100644
  
 -AUTODOCS_YCP = $(srcdir)/../../src/*/*.ycp
  include $(top_srcdir)/autodocs-ycp.ami
+diff --git a/src/include/network/installation/dialogs.ycp b/src/include/network/installation/dialogs.ycp
+index 2922fab..6b8aa13 100644
+--- a/src/include/network/installation/dialogs.ycp
++++ b/src/include/network/installation/dialogs.ycp
+@@ -222,7 +222,6 @@ string current = Internet::device;
+ 	case `cancel:
+ 	    if (Popup::ConfirmAbort (`incomplete)){
+ 		exit=true;
+-		break;
+ 		}
+             break;
+ 	case `next:
 diff --git a/src/include/network/lan/complex.ycp b/src/include/network/lan/complex.ycp
 index e11a8a4..0dc4672 100644
 --- a/src/include/network/lan/complex.ycp
@@ -93,10 +105,10 @@ index d9b12b0..e85fbc8 100644
  testsuite_prepare = @ydatadir@/testsuite/Makefile.testsuite
  
 diff --git a/yast2-network.spec.in b/yast2-network.spec.in
-index b41414a..f5e8688 100644
+index 20ce0da..843f838 100644
 --- a/yast2-network.spec.in
 +++ b/yast2-network.spec.in
-@@ -30,6 +30,8 @@ PreReq:         /bin/rm
+@@ -31,6 +31,8 @@ PreReq:         /bin/rm
  # carrier detection
  Conflicts:      yast2-core < 2.10.6
  
@@ -105,7 +117,7 @@ index b41414a..f5e8688 100644
  Summary:        YaST2 - Network Configuration
  
  %package devel-doc
-@@ -72,10 +74,9 @@ fi
+@@ -73,10 +75,9 @@ fi
  @ybindir@/*
  @ydatadir@/*
  @yncludedir@/network

--- a/patches/sudo.patch
+++ b/patches/sudo.patch
@@ -12,6 +12,19 @@ index 28b8611..31180cb 100644
 +scrconf_DATA =
  
  EXTRA_DIST = $(agent_SCRIPTS) $(scrconf_DATA)
+diff --git a/src/modules/Sudo.ycp b/src/modules/Sudo.ycp
+index dfa02b9..2e7fd16 100644
+--- a/src/modules/Sudo.ycp
++++ b/src/modules/Sudo.ycp
+@@ -145,8 +145,6 @@ boolean ReadSudoSettings2() {
+ 			m["comment"] = line[0]:"";
+ 
+ 			rules = add(rules,m);
+-			break;
+-	
+ 			}
+ 		    }
+ 		}
 diff --git a/testsuite/Makefile.am b/testsuite/Makefile.am
 index d9b12b0..e85fbc8 100644
 --- a/testsuite/Makefile.am


### PR DESCRIPTION
"break" statements in the middle of "case" od "default" clauses are
impossible to translate correctly. So I added a detection of these into
Y2R (see commit e61c432579102d6b16627c6a2c8fac24ad123172 there) and
patched all known occurrences (there were just 2).

Fixes #605.
