### PR TITLE
Use SSH URLs for cloning from GitHub

### DIFF
--- a/lib/commands/clone_command.rb
+++ b/lib/commands/clone_command.rb
@@ -8,7 +8,7 @@ module Commands
       action "Cloning" do
         FileUtils.rm_rf(mod.work_dir)
 
-        Cheetah.run "git", "clone", "git://github.com/yast/yast-#{mod.name}.git", mod.work_dir
+        Cheetah.run "git", "clone", "git@github.com:yast/yast-#{mod.name}.git", mod.work_dir
       end
     end
   end


### PR DESCRIPTION
This will allow us to push stuff from work and result dirs back to
GitHub repos during the final compilation.
