### PR TITLE
Add --ref, --branch and --tag options to "yk clone"

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,9 @@ Clones module source from Git repository for each specified module using `git
 clone`. The clone is placed into module's work directory. If the work directory
 already exists, it is deleted before cloning.
 
+Use the `--ref=REF`, `--branch=BRANCH`, or `--tag=TAG` option to specify a ref,
+branch, or tag to clone.
+
 #### yk convert
 
 Runs all conversion-related tasks for each specified module. Rough equivalent of

--- a/lib/commands/clone_command.rb
+++ b/lib/commands/clone_command.rb
@@ -4,11 +4,19 @@ require_relative "command"
 
 module Commands
   class CloneCommand < Command
+    def initialize(options = {})
+      @ref = options[:ref] || options[:branch] || options[:tag] || "master"
+    end
+
     def apply(mod)
       action "Cloning" do
         FileUtils.rm_rf(mod.work_dir)
 
-        Cheetah.run "git", "clone", "git@github.com:yast/yast-#{mod.name}.git", mod.work_dir
+        Cheetah.run "git", "clone", "--no-checkout", "git@github.com:yast/yast-#{mod.name}.git", mod.work_dir
+
+        Dir.chdir mod.work_dir do
+          Cheetah.run "git", "checkout", @ref
+        end
       end
     end
   end

--- a/yk
+++ b/yk
@@ -70,10 +70,13 @@ class CLI < Thor
   end
 
   desc "clone <module>...", "Clone module source from Git repository"
+  option :ref,    :type => :string, :desc => "A ref to clone from"
+  option :branch, :type => :string, :desc => "A branch to clone from"
+  option :tag,    :type => :string, :desc => "A tag to clone from"
   def clone(*module_names)
     modules = modules_from_names(module_names)
     with_modules modules do |mod|
-      Commands::CloneCommand.new.apply(mod)
+      Commands::CloneCommand.new(options).apply(mod)
     end
   end
 


### PR DESCRIPTION
The --branch and --tag options are equal to --ref, they are just
provided for readability (this is inspired by Bundler).

These options will allow YCP Killer to be used even after the final
conversion to Ruby was done in master. This might be useful e.g. for
porting SLE fixes (which must be done in YCP) to master.
